### PR TITLE
Update .gitignore to exclude additional files and directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -177,3 +177,7 @@ cython_debug/
 # Other files
 wandb/
 checkpoints/
+model_checkpoints/
+outputs/
+*.mp4
+.DS_Store


### PR DESCRIPTION
Add entries to the .gitignore file to exclude model checkpoints, outputs, video files, and macOS system files.