### PR TITLE
Change speed reward to zero by default for rodent bowl escape

### DIFF
--- a/vnl_playground/tasks/rodent/bowl_escape.py
+++ b/vnl_playground/tasks/rodent/bowl_escape.py
@@ -86,7 +86,7 @@ def default_config() -> config_dict.ConfigDict:
         bowl_amplitude=-10,
         reward_terms={
             "escape_x_upright": {"weight": 1.0},
-            "speed": {"weight": 1.0},
+            "speed": {"weight": 0.0},
         },
         termination_criteria={
             "fallen": {},


### PR DESCRIPTION
# Summary
Changes the default speed reward weight to zero in `vnl_playground/tasks/rodent/bowl_escape.py`