### PR TITLE
Fix prev_action ordering in rodent tasks and LegacyObsWrapper model access

### DIFF
--- a/vnl_playground/tasks/reference_clips.py
+++ b/vnl_playground/tasks/reference_clips.py
@@ -255,8 +255,10 @@ class ReferenceClips:
                 if keep_clips_idx is not None:
                     logging.info(f"{k}: Keeping {len(keep_clips_idx)} clips")
                     self._data_arrays[k] = self._data_arrays[k][keep_clips_idx]
-                    if self.clip_names is not None:
-                        self.clip_names = self.clip_names[keep_clips_idx]
+
+        # Filter clip names once (outside the loop to avoid repeated indexing)
+        if keep_clips_idx is not None and self.clip_names is not None:
+            self.clip_names = self.clip_names[keep_clips_idx]
 
         # Load name mappings
         if "names_qpos" in fid:

--- a/vnl_playground/tasks/rodent/bowl_escape.py
+++ b/vnl_playground/tasks/rodent/bowl_escape.py
@@ -207,10 +207,10 @@ class BowlEscape(rodent_base.RodentEnv):
         data = mjx_env.step(self.mjx_model, state.data, action, n_steps)
 
         info = state.info
-        obs = self._get_obs(data, info)
-
         info["prev_action"] = info["action"]
         info["action"] = action
+
+        obs = self._get_obs(data, info)
 
         done = self._is_done(data, info, state.metrics)
         reward = self._get_reward(data, info, state.metrics)

--- a/vnl_playground/tasks/rodent/maintain_velocity.py
+++ b/vnl_playground/tasks/rodent/maintain_velocity.py
@@ -146,10 +146,10 @@ class MaintainVelocity(rodent_base.RodentEnv):
         data = mjx_env.step(self.mjx_model, state.data, action, n_steps)
 
         info = state.info
-        obs = self._get_obs(data, info)
-
         info["prev_action"] = info["action"]
         info["action"] = action
+
+        obs = self._get_obs(data, info)
 
         done = self._is_done(data, info, state.metrics)
         reward = self._get_reward(data, info, state.metrics)

--- a/vnl_playground/tasks/rodent/rearing.py
+++ b/vnl_playground/tasks/rodent/rearing.py
@@ -115,10 +115,10 @@ class Rearing(rodent_base.RodentEnv):
         data = mjx_env.step(self.mjx_model, state.data, action, n_steps)
 
         info = state.info.copy()
-        obs = self._get_obs(data, info)
-
         info["prev_action"] = info["action"]
         info["action"] = action
+
+        obs = self._get_obs(data, info)
 
         # Update rearing step counter with reset requirement
         relative_height = self._get_relative_head_height(data)

--- a/vnl_playground/tasks/wrappers.py
+++ b/vnl_playground/tasks/wrappers.py
@@ -194,6 +194,18 @@ class LegacyObsWrapper(wrapper.Wrapper):
         return state.replace(obs=state.obs[self._obs_key])
 
     @property
+    def unwrapped(self) -> mjx_env.MjxEnv:
+        return self
+
+    @property
+    def _mjx_model(self):
+        return self.env._mjx_model
+
+    @_mjx_model.setter
+    def _mjx_model(self, value):
+        self.env._mjx_model = value
+
+    @property
     def non_flattened_observation_size(self):
         return self.env.non_flattened_observation_size[self._obs_key]
 


### PR DESCRIPTION
Summary

  - Fix stale prev_action in rodent tasks: bowl_escape, maintain_velocity, and rearing computed
  observations before updating prev_action, causing proprioception to contain the action from two steps ago
   instead of one. This created distribution shift for policies trained on the imitation environment where
  the ordering is correct.
  - Fix clip_names filtering: Moved clip_names indexing outside the per-array loop in ReferenceClips to
  avoid redundant repeated filtering.
  - Add model proxy to LegacyObsWrapper: Expose unwrapped and _mjx_model properties so wrapped environments
   can be used where the underlying model is needed.