### PR TITLE
chore: ignore highlvl_checkpoints/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -185,3 +185,4 @@ outputs/
 *.mp4
 *.png
 vnl_playground/_version.py
+highlvl_checkpoints/


### PR DESCRIPTION
## Summary
Adds `highlvl_checkpoints/` to `.gitignore` so high-level prior-rollout checkpoint artifacts aren't accidentally tracked. Mirrors the existing `checkpoints/` and `model_checkpoints/` entries.

## Change
- `.gitignore`: +1 line (`highlvl_checkpoints/`)

No code or behavior changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)