### PR TITLE
fix: use inv_rotate for egocentric imitation targets to match proprioception convention

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
     {name = "Aidan Sirbu", email = "aidan.sirbu@mail.mcgill.ca"},
     {name = "Talmo Pereira", email = "talmo@salk.edu"}]
 description=  "VNL-PLAYGROUND: A Python package for fast reinforcement learning-based imitation learning tracking for agents"
-requires-python = ">=3.7"
+requires-python = ">=3.11"
 keywords = ["tracking", "imitation learning", "deep learning"]
 license = {text = "BSD-3-Clause"}
 classifiers = [

--- a/vnl_playground/tasks/celegans/imitation.py
+++ b/vnl_playground/tasks/celegans/imitation.py
@@ -522,7 +522,7 @@ class Imitation(worm_base.CelegansEnv):
         root_pos = self.root_body(data).xpos
         root_quat = self.root_body(data).xquat
         root_targets = jax.vmap(
-            lambda ref_pos: brax.math.rotate(ref_pos - root_pos, root_quat)[
+            lambda ref_pos: brax.math.inv_rotate(ref_pos - root_pos, root_quat)[
                 : self.config.dim
             ]
         )(reference.body_xpos(self.root_name))
@@ -543,7 +543,7 @@ class Imitation(worm_base.CelegansEnv):
             [reference.body_xpos(name) - bodies_pos[name] for name in bodies_pos]
         )
         to_egocentric = jax.vmap(
-            lambda diff_vec: brax.math.rotate(diff_vec, root_quat)[: self._config.dim]
+            lambda diff_vec: brax.math.inv_rotate(diff_vec, root_quat)[: self._config.dim]
         )
         body_targets = jax.vmap(to_egocentric)(body_rel_pos)
 

--- a/vnl_playground/tasks/celegans/imitation.py
+++ b/vnl_playground/tasks/celegans/imitation.py
@@ -543,7 +543,9 @@ class Imitation(worm_base.CelegansEnv):
             [reference.body_xpos(name) - bodies_pos[name] for name in bodies_pos]
         )
         to_egocentric = jax.vmap(
-            lambda diff_vec: brax.math.inv_rotate(diff_vec, root_quat)[: self._config.dim]
+            lambda diff_vec: brax.math.inv_rotate(diff_vec, root_quat)[
+                : self._config.dim
+            ]
         )
         body_targets = jax.vmap(to_egocentric)(body_rel_pos)
 

--- a/vnl_playground/tasks/fruitfly/imitation.py
+++ b/vnl_playground/tasks/fruitfly/imitation.py
@@ -279,7 +279,7 @@ class Imitation(fruitfly_base.FruitflyEnv):
         root_pos = self.root_body(data).xpos
         root_quat = self.root_body(data).xquat
         root_targets = jax.vmap(
-            lambda ref_pos: brax.math.rotate(ref_pos - root_pos, root_quat)
+            lambda ref_pos: brax.math.inv_rotate(ref_pos - root_pos, root_quat)
         )(reference.root_position)
         quat_targets = jax.vmap(
             lambda ref_quat: brax.math.relative_quat(ref_quat, root_quat)
@@ -291,7 +291,7 @@ class Imitation(fruitfly_base.FruitflyEnv):
         body_rel_pos = jp.array(
             [reference.body_xpos(name) - bodies_pos[name] for name in bodies_pos]
         )
-        to_egocentric = jax.vmap(lambda diff_vec: brax.math.rotate(diff_vec, root_quat))
+        to_egocentric = jax.vmap(lambda diff_vec: brax.math.inv_rotate(diff_vec, root_quat))
         body_targets = jax.vmap(to_egocentric)(body_rel_pos)
 
         return collections.OrderedDict(

--- a/vnl_playground/tasks/fruitfly/imitation.py
+++ b/vnl_playground/tasks/fruitfly/imitation.py
@@ -291,7 +291,9 @@ class Imitation(fruitfly_base.FruitflyEnv):
         body_rel_pos = jp.array(
             [reference.body_xpos(name) - bodies_pos[name] for name in bodies_pos]
         )
-        to_egocentric = jax.vmap(lambda diff_vec: brax.math.inv_rotate(diff_vec, root_quat))
+        to_egocentric = jax.vmap(
+            lambda diff_vec: brax.math.inv_rotate(diff_vec, root_quat)
+        )
         body_targets = jax.vmap(to_egocentric)(body_rel_pos)
 
         return collections.OrderedDict(

--- a/vnl_playground/tasks/rodent/imitation.py
+++ b/vnl_playground/tasks/rodent/imitation.py
@@ -327,7 +327,9 @@ class Imitation(rodent_base.RodentEnv):
         body_rel_pos = jp.array(
             [reference.body_xpos(name) - bodies_pos[name] for name in bodies_pos]
         )
-        to_egocentric = jax.vmap(lambda diff_vec: brax.math.inv_rotate(diff_vec, root_quat))
+        to_egocentric = jax.vmap(
+            lambda diff_vec: brax.math.inv_rotate(diff_vec, root_quat)
+        )
         body_targets = jax.vmap(to_egocentric)(body_rel_pos)
 
         return collections.OrderedDict(

--- a/vnl_playground/tasks/rodent/imitation.py
+++ b/vnl_playground/tasks/rodent/imitation.py
@@ -309,7 +309,7 @@ class Imitation(rodent_base.RodentEnv):
         root_pos = self.root_body(data).xpos
         root_quat = self.root_body(data).xquat
         root_targets = jax.vmap(
-            lambda ref_pos: brax.math.rotate(ref_pos - root_pos, root_quat)
+            lambda ref_pos: brax.math.inv_rotate(ref_pos - root_pos, root_quat)
         )(reference.root_position)
         quat_targets = jax.vmap(
             lambda ref_quat: brax.math.relative_quat(ref_quat, root_quat)
@@ -327,7 +327,7 @@ class Imitation(rodent_base.RodentEnv):
         body_rel_pos = jp.array(
             [reference.body_xpos(name) - bodies_pos[name] for name in bodies_pos]
         )
-        to_egocentric = jax.vmap(lambda diff_vec: brax.math.rotate(diff_vec, root_quat))
+        to_egocentric = jax.vmap(lambda diff_vec: brax.math.inv_rotate(diff_vec, root_quat))
         body_targets = jax.vmap(to_egocentric)(body_rel_pos)
 
         return collections.OrderedDict(

--- a/vnl_playground/tasks/stick/imitation.py
+++ b/vnl_playground/tasks/stick/imitation.py
@@ -274,7 +274,9 @@ class Imitation(stick_base.StickBugEnv):
         body_rel_pos = jp.array(
             [reference.body_xpos(name) - bodies_pos[name] for name in bodies_pos]
         )
-        to_egocentric = jax.vmap(lambda diff_vec: brax.math.inv_rotate(diff_vec, root_quat))
+        to_egocentric = jax.vmap(
+            lambda diff_vec: brax.math.inv_rotate(diff_vec, root_quat)
+        )
         body_targets = jax.vmap(to_egocentric)(body_rel_pos)
 
         return collections.OrderedDict(

--- a/vnl_playground/tasks/stick/imitation.py
+++ b/vnl_playground/tasks/stick/imitation.py
@@ -256,7 +256,7 @@ class Imitation(stick_base.StickBugEnv):
         root_pos = self.root_body(data).xpos
         root_quat = self.root_body(data).xquat
         root_targets = jax.vmap(
-            lambda ref_pos: brax.math.rotate(ref_pos - root_pos, root_quat)
+            lambda ref_pos: brax.math.inv_rotate(ref_pos - root_pos, root_quat)
         )(reference.root_position)
         quat_targets = jax.vmap(
             lambda ref_quat: brax.math.relative_quat(ref_quat, root_quat)
@@ -274,7 +274,7 @@ class Imitation(stick_base.StickBugEnv):
         body_rel_pos = jp.array(
             [reference.body_xpos(name) - bodies_pos[name] for name in bodies_pos]
         )
-        to_egocentric = jax.vmap(lambda diff_vec: brax.math.rotate(diff_vec, root_quat))
+        to_egocentric = jax.vmap(lambda diff_vec: brax.math.inv_rotate(diff_vec, root_quat))
         body_targets = jax.vmap(to_egocentric)(body_rel_pos)
 
         return collections.OrderedDict(


### PR DESCRIPTION
## Summary

`_get_imitation_target()` across all four morphologies used `brax.math.rotate(diff, q)` to transform position deltas into the root body's egocentric frame. This applies `R @ v` (active rotation). However, the proprioception code in `base.py:185` uses `jp.dot(diff, xmat)`, which applies `v @ R = R^T @ v` (passive / body-frame projection). The imitation targets were therefore presented in the **transposed** frame relative to the rest of the agent's egocentric observations.

The fix replaces `brax.math.rotate` with `brax.math.inv_rotate` (which applies `R^T @ v`) in the two call sites per morphology, aligning imitation targets with the proprioception convention.

## Mathematical detail

For a body with orientation quaternion `q` and corresponding rotation matrix `R = quat_to_mat(q)`:

| Function | Operation | Frame |
|---|---|---|
| `brax.math.rotate(v, q)` | `R @ v` | local-to-global |
| `brax.math.inv_rotate(v, q)` | `R^T @ v` | global-to-local (egocentric) |
| `jp.dot(v, xmat)` | `v @ R = R^T @ v` | global-to-local (egocentric) |

Proprioception (`base.py:185`) uses `jp.dot(global_xpos - torso.xpos, torso.xmat)`, i.e. `R^T @ v`. The imitation targets must use the same convention. The old code used `rotate` (`R @ v`), producing targets in the *inverse* of the intended frame. This is equivalent to reflecting the target through the body's local axes.