### PR TITLE
Migrate formatting and linting to Ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,12 @@ jobs:
 
       - name: Install linting tools
         run: |
-          pip install "black[jupyter]"
+          pip install ruff
 
-      - name: Run Black
+      - name: Run Ruff format check
         run: |
-          black --check --diff vnl_playground/ notebooks/
+          ruff format --check vnl_playground/
+
+      - name: Run Ruff lint
+        run: |
+          ruff check vnl_playground/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ version_file = "vnl_playground/_version.py"
 cuda12 = ["jax[cuda12]>=0.7.2 ; sys_platform == 'linux'"]
 cuda13 = ["jax[cuda13]>=0.7.2 ; sys_platform == 'linux'"]
 dev = [
-    "black[jupyter]>=26.1.0",
+    "ruff>=0.11",
 ]
 
 with-cuda = [
@@ -75,5 +75,36 @@ include-package-data = true
 [tool.setuptools.packages.find]
 exclude = ["site", "model_checkpoints*", "checkpoints*", "wandb*", "outputs"]
 
-[tool.black]
+[tool.ruff]
 line-length = 88
+target-version = "py311"
+
+[tool.ruff.format]
+docstring-code-format = true
+
+[tool.ruff.lint]
+select = [
+    "E",      # pycodestyle errors
+    "W",      # pycodestyle warnings
+    "F",      # pyflakes
+    "I",      # isort
+    "UP",     # pyupgrade (modernize syntax for target Python)
+    "B",      # flake8-bugbear
+    "SIM",    # flake8-simplify
+    "TCH",    # flake8-type-checking (move imports behind TYPE_CHECKING)
+    "RUF",    # ruff-specific rules
+]
+ignore = [
+    "E501",    # line too long (formatter handles this)
+    "B008",    # function call in default arg (safe for partials and initializers)
+    "B905",    # zip() without strict= (too noisy for JAX code)
+    "RUF059",  # unused unpacked variable (common in ML code)
+]
+
+[tool.ruff.lint.per-file-ignores]
+"vnl_playground/train_*.py" = [
+    "E402",  # entrypoints configure rendering/JAX before accelerator imports
+]
+
+[tool.ruff.lint.isort]
+known-first-party = ["vnl_playground"]

--- a/vnl_playground/registry.py
+++ b/vnl_playground/registry.py
@@ -15,7 +15,7 @@ Usage:
     clips = registry.load_reference_clips("RodentImitation", data_path, ...)
 """
 
-from typing import Any, Optional
+from typing import Any
 
 from ml_collections import config_dict
 
@@ -40,7 +40,7 @@ def get_default_config(env_name: str) -> config_dict.ConfigDict:
 
 def load(
     env_name: str,
-    config: Optional[config_dict.ConfigDict] = None,
+    config: config_dict.ConfigDict | None = None,
     clips: Any = None,
     flatten_obs: bool = True,
     **kwargs,

--- a/vnl_playground/tasks/__init__.py
+++ b/vnl_playground/tasks/__init__.py
@@ -4,32 +4,31 @@ Like mujoco_playground's locomotion/__init__.py - static imports,
 dict-based registry, load() function.
 """
 
-from typing import Any, Callable, Optional, Type
+from collections.abc import Callable
+from typing import Any
 
 from ml_collections import config_dict
 
-from vnl_playground.tasks.rodent import imitation as rodent_imitation
-from vnl_playground.tasks.rodent import sparse_imitation as rodent_sparse_imitation
-from vnl_playground.tasks.rodent import rearing as rodent_rearing
-from vnl_playground.tasks.rodent import bowl_escape as rodent_bowl_escape
-from vnl_playground.tasks.rodent import maintain_velocity as rodent_maintain_velocity
-from vnl_playground.tasks.rodent import joystick as rodent_joystick
+from vnl_playground.tasks.celegans import imitation as worm_imitation
 from vnl_playground.tasks.fruitfly import imitation as fruitfly_imitation
 from vnl_playground.tasks.fruitfly import (
     maintain_velocity as fruitfly_maintain_velocity,
 )
-
 from vnl_playground.tasks.mouse import imitation as mouse_imitation
 from vnl_playground.tasks.mouse import mouse_reach
 from vnl_playground.tasks.mouse.reference_clips import MouseReferenceClips
-from vnl_playground.tasks.stick import maintain_velocity as stick_maintain_velocity
+from vnl_playground.tasks.reference_clips import ReferenceClips
+from vnl_playground.tasks.rodent import bowl_escape as rodent_bowl_escape
+from vnl_playground.tasks.rodent import imitation as rodent_imitation
+from vnl_playground.tasks.rodent import joystick as rodent_joystick
+from vnl_playground.tasks.rodent import maintain_velocity as rodent_maintain_velocity
+from vnl_playground.tasks.rodent import rearing as rodent_rearing
+from vnl_playground.tasks.rodent import sparse_imitation as rodent_sparse_imitation
 from vnl_playground.tasks.stick import imitation as stick_imitation
-
-from vnl_playground.tasks.celegans import imitation as worm_imitation
+from vnl_playground.tasks.stick import maintain_velocity as stick_maintain_velocity
 
 # Unified wrappers and reference clips
 from vnl_playground.tasks.wrappers import FlattenObsWrapper
-from vnl_playground.tasks.reference_clips import ReferenceClips
 
 # Registry dicts (like locomotion's _envs, _cfgs)
 _envs = {
@@ -85,10 +84,10 @@ def __getattr__(name):
 
 def register_environment(
     env_name: str,
-    env_class: Type,
+    env_class: type,
     cfg_class: Callable[[], config_dict.ConfigDict],
-    wrapper_class: Optional[Type] = None,
-    reference_clips_class: Optional[Type] = None,
+    wrapper_class: type | None = None,
+    reference_clips_class: type | None = None,
 ) -> None:
     """Register a new environment at runtime."""
     _envs[env_name] = env_class
@@ -109,7 +108,7 @@ def get_default_config(env_name: str) -> config_dict.ConfigDict:
 
 def load(
     env_name: str,
-    config: Optional[config_dict.ConfigDict] = None,
+    config: config_dict.ConfigDict | None = None,
     clips: Any = None,
     flatten_obs: bool = True,
     **kwargs,

--- a/vnl_playground/tasks/celegans/base.py
+++ b/vnl_playground/tasks/celegans/base.py
@@ -6,24 +6,25 @@ creating and managing C. elegans simulation environments using MuJoCo.
 
 import collections
 import logging
-from typing import Any, Dict, List, Optional, Tuple, Union, Mapping
-from xml.etree import ElementTree as ET
+from collections.abc import Mapping
 from pprint import pformat
+from typing import Any
+from xml.etree import ElementTree as ET
 
 import jax
 import jax.numpy as jp
 import mujoco
 import numpy as np
-from etils import epath
 from ml_collections import config_dict
 from mujoco import mjx
 from mujoco_playground._src import mjx_env
+
 from vnl_playground.tasks.celegans import consts
-from vnl_playground.tasks.utils import _recolour_tree, scale_spec
 from vnl_playground.tasks.reward_registry import RewardRegistry
+from vnl_playground.tasks.utils import _recolour_tree, scale_spec
 
 
-def get_assets() -> Dict[str, bytes]:
+def get_assets() -> dict[str, bytes]:
     """Get asset files for C. elegans environment.
 
     Returns:
@@ -99,7 +100,7 @@ class CelegansEnv(mjx_env.MjxEnv):
     def __init__(
         self,
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, List[Any]]]] = None,
+        config_overrides: dict[str, str | int | list[Any]] | None = None,
     ) -> None:
         """Initialize the CelegansEnv class with only arena.
 
@@ -164,16 +165,16 @@ class CelegansEnv(mjx_env.MjxEnv):
         torque_actuators: bool,
         rescale_factor: float = 1.0,
         trans_joint: str = "slide",
-        pos: Tuple[float, float, float] = (0, 0, 0.05),
-        quat: Tuple[float, float, float, float] = (1, 0, 0, 0),
-        friction: Tuple[float, ...] = BASE_CONFIG.friction,
-        solimp: Tuple[float, ...] = BASE_CONFIG.solimp,
-        solref: Tuple[float, ...] = BASE_CONFIG.solref,
-        solreffriction: Tuple[float, ...] = BASE_CONFIG.solreffriction,
-        muscle_config: Optional[Dict[str, Any]] = BASE_CONFIG.muscle_config,
-        joint_config: Optional[Dict[str, Any]] = BASE_CONFIG.joint_config,
-        contact_geom: Optional[mujoco.mjtGeom] = mujoco.mjtGeom.mjGEOM_CAPSULE,
-        rgba: Optional[Tuple[float, float, float, float]] = None,
+        pos: tuple[float, float, float] = (0, 0, 0.05),
+        quat: tuple[float, float, float, float] = (1, 0, 0, 0),
+        friction: tuple[float, ...] = BASE_CONFIG.friction,
+        solimp: tuple[float, ...] = BASE_CONFIG.solimp,
+        solref: tuple[float, ...] = BASE_CONFIG.solref,
+        solreffriction: tuple[float, ...] = BASE_CONFIG.solreffriction,
+        muscle_config: dict[str, Any] | None = BASE_CONFIG.muscle_config,
+        joint_config: dict[str, Any] | None = BASE_CONFIG.joint_config,
+        contact_geom: mujoco.mjtGeom | None = mujoco.mjtGeom.mjGEOM_CAPSULE,
+        rgba: tuple[float, float, float, float] | None = None,
         suffix: str = "-worm",
     ) -> None:
         """Adds the c. elegans model to the environment.
@@ -190,7 +191,7 @@ class CelegansEnv(mjx_env.MjxEnv):
         print(f"Loading worm from {self._walker_xml_path}")
         worm = mujoco.MjSpec.from_file(self._walker_xml_path)
 
-        # a) Convert motors to torque‑mode if requested
+        # a) Convert motors to torque-mode if requested
         if torque_actuators and hasattr(worm, "actuator"):
             logging.info("Converting to torque actuators")
             for actuator in worm.actuators:  # type: ignore[attr-defined]
@@ -306,7 +307,7 @@ class CelegansEnv(mjx_env.MjxEnv):
                         for i, (key, default) in enumerate(default_gainprm.items()):
                             gainprm[i] = value.get(key, default)
                         muscle.gainprm = gainprm
-                        if "biasprm" not in muscle_config.keys():
+                        if "biasprm" not in muscle_config:
                             muscle.biasprm = gainprm
                     elif key == "gear":
                         gear = np.zeros_like(muscle.gear)
@@ -342,12 +343,12 @@ class CelegansEnv(mjx_env.MjxEnv):
     def add_ghost(
         self,
         rescale_factor: float = 1.0,
-        pos: Tuple[float, float, float] = (0, 0, 0.05),
-        ghost_rgba: Tuple[float, float, float, float] = (0.8, 0.8, 0.8, 0.3),
+        pos: tuple[float, float, float] = (0, 0, 0.05),
+        ghost_rgba: tuple[float, float, float, float] = (0.8, 0.8, 0.8, 0.3),
         suffix: str = "-ghost",
         trans_joint: str = "slide",
         inplace: bool = False,
-    ) -> Optional[Tuple[mujoco.MjSpec, mujoco.MjModel]]:
+    ) -> tuple[mujoco.MjSpec, mujoco.MjModel] | None:
         """Add a ghost worm model to the environment.
 
         Args:
@@ -364,10 +365,7 @@ class CelegansEnv(mjx_env.MjxEnv):
         """
         print(f"Loading ghost worm from {self._walker_xml_path}")
 
-        if not inplace:
-            spec = self._spec.copy()
-        else:
-            spec = self._spec
+        spec = self._spec.copy() if not inplace else self._spec
 
         walker_spec = mujoco.MjSpec.from_file(self._walker_xml_path)
         if rescale_factor != 1.0:
@@ -535,7 +533,7 @@ class CelegansEnv(mjx_env.MjxEnv):
 
     def _get_appendages_pos(
         self, data: mjx.Data, flatten: bool = True
-    ) -> Union[jp.ndarray, Dict[str, jp.ndarray]]:
+    ) -> jp.ndarray | dict[str, jp.ndarray]:
         """Get appendages positions from the environment.
 
         Args:
@@ -562,7 +560,7 @@ class CelegansEnv(mjx_env.MjxEnv):
 
     def _get_bodies_pos(
         self, data: mjx.Data, flatten: bool = True
-    ) -> Union[Dict[str, jp.ndarray], jp.ndarray]:
+    ) -> dict[str, jp.ndarray] | jp.ndarray:
         """Get global positions of the body parts.
 
         Args:
@@ -585,7 +583,7 @@ class CelegansEnv(mjx_env.MjxEnv):
 
     def _get_joint_angles(
         self, data: mjx.Data, flatten: bool = True
-    ) -> Union[jp.ndarray, Dict[str, jp.ndarray]]:
+    ) -> jp.ndarray | dict[str, jp.ndarray]:
         """Get joint angles of the body parts.
 
         Args:
@@ -602,18 +600,17 @@ class CelegansEnv(mjx_env.MjxEnv):
                 joint_angles[joint_name] = data.bind(
                     self.mjx_model, self.spec.joint(f"{joint_name}{self.suffix}")
                 ).qpos
-            except Exception as e:
-                print(e)
+            except Exception as error:
                 raise ValueError(
                     f"Joint {joint_name}{self._suffix} not found in the environment.\nAvailable joints: {[joint.name for joint in self._spec.joints]}"
-                )
+                ) from error
         if flatten:
             joint_angles, _ = jax.flatten_util.ravel_pytree(joint_angles)
         return joint_angles
 
     def _get_joint_ang_vels(
         self, data: mjx.Data, flatten: bool = True
-    ) -> Union[jp.ndarray, Dict[str, jp.ndarray]]:
+    ) -> jp.ndarray | dict[str, jp.ndarray]:
         """Get joint angular velocities of the body parts.
 
         Args:
@@ -674,9 +671,9 @@ class CelegansEnv(mjx_env.MjxEnv):
         self,
         data: mjx.Data,
         info: Mapping[str, Any],
-        filter_keys: List[str] = [],
+        filter_keys: list[str] | None = None,
         flatten: bool = True,
-    ) -> Union[jp.ndarray, Dict[str, Any]]:
+    ) -> jp.ndarray | dict[str, Any]:
         """Get proprioception data from the environment.
 
         Args:
@@ -697,7 +694,7 @@ class CelegansEnv(mjx_env.MjxEnv):
             kinematic_sensors=self._get_kinematic_sensors(data, flatten=flatten),
             prev_action=info["prev_action"],
         )
-        for key in filter_keys:
+        for key in filter_keys or ():
             proprioception.pop(key)
         if flatten:
             proprioception, _ = jax.flatten_util.ravel_pytree(proprioception)
@@ -705,7 +702,7 @@ class CelegansEnv(mjx_env.MjxEnv):
 
     def _get_kinematic_sensors(
         self, data: mjx.Data, flatten: bool = True
-    ) -> Union[jp.ndarray, Dict[str, jp.ndarray]]:
+    ) -> jp.ndarray | dict[str, jp.ndarray]:
         """Get kinematic sensors data from the environment.
 
         Args:
@@ -830,7 +827,9 @@ class CelegansEnv(mjx_env.MjxEnv):
             self.mjx_model, self._spec.sensor(f"velocimeter{self._suffix}")
         ).sensordata
 
-    def subtree_linvel(self, data: mjx.Data, body_name: str = None) -> jp.ndarray:
+    def subtree_linvel(
+        self, data: mjx.Data, body_name: str | None = None
+    ) -> jp.ndarray:
         """Get the subtree linear velocity sensor data.
 
         Args:
@@ -848,7 +847,7 @@ class CelegansEnv(mjx_env.MjxEnv):
             self.mjx_model, self._spec.sensor(f"subtreelinvel{self._suffix}")
         ).sensordata
 
-    def save_spec(self, path: str, return_str: bool = False) -> Optional[str]:
+    def save_spec(self, path: str, return_str: bool = False) -> str | None:
         """Save the spec to a file.
 
         Args:
@@ -949,7 +948,7 @@ class CelegansEnv(mjx_env.MjxEnv):
         self._max_reward = max_reward
 
     @property
-    def rewards(self) -> Dict[str, Any]:
+    def rewards(self) -> dict[str, Any]:
         """Get the reward terms.
 
         Returns:
@@ -958,7 +957,7 @@ class CelegansEnv(mjx_env.MjxEnv):
         return self.registry.rewards
 
     @property
-    def costs(self) -> Dict[str, Any]:
+    def costs(self) -> dict[str, Any]:
         """Get the cost terms.
 
         Returns:
@@ -967,7 +966,7 @@ class CelegansEnv(mjx_env.MjxEnv):
         return self.registry.costs
 
     @property
-    def terminations(self) -> Dict[str, Any]:
+    def terminations(self) -> dict[str, Any]:
         """Get the termination terms.
 
         Returns:
@@ -1102,7 +1101,7 @@ class CelegansEnv(mjx_env.MjxEnv):
         return self.config.get("root_body", consts.ROOT)
 
     @property
-    def joint_names(self) -> List[str]:
+    def joint_names(self) -> list[str]:
         """Get the list of joint names in the configuration.
 
         Returns:
@@ -1111,7 +1110,7 @@ class CelegansEnv(mjx_env.MjxEnv):
         return self.config.get("joints", consts.JOINTS)
 
     @property
-    def body_names(self) -> List[str]:
+    def body_names(self) -> list[str]:
         """Get the list of body names in the configuration.
 
         Returns:
@@ -1120,7 +1119,7 @@ class CelegansEnv(mjx_env.MjxEnv):
         return self.config.get("bodies", consts.BODIES)
 
     @property
-    def end_eff_names(self) -> List[str]:
+    def end_eff_names(self) -> list[str]:
         """Get the list of end effector names in the configuration.
 
         Returns:
@@ -1129,7 +1128,7 @@ class CelegansEnv(mjx_env.MjxEnv):
         return self.config.get("end_effectors", consts.END_EFFECTORS)
 
     @property
-    def touch_sensor_names(self) -> List[str]:
+    def touch_sensor_names(self) -> list[str]:
         """Get the list of touch sensor names in the configuration.
 
         Returns:
@@ -1138,7 +1137,7 @@ class CelegansEnv(mjx_env.MjxEnv):
         return self.config.get("touch_sensors", consts.TOUCH_SENSORS)
 
     @property
-    def sensor_names(self) -> List[str]:
+    def sensor_names(self) -> list[str]:
         """Get the list of sensor names in the configuration.
 
         Returns:
@@ -1174,7 +1173,7 @@ class CelegansEnv(mjx_env.MjxEnv):
         return len(self.end_eff_names)
 
     @property
-    def camera_names(self) -> List[str]:
+    def camera_names(self) -> list[str]:
         """Get the list of camera names in the configuration.
 
         Returns:

--- a/vnl_playground/tasks/celegans/consts.py
+++ b/vnl_playground/tasks/celegans/consts.py
@@ -4,8 +4,6 @@ This module contains path definitions and configuration constants used
 throughout the C. elegans simulation environment.
 """
 
-from typing import List
-
 from etils import epath
 
 CELEGANS_PATH: epath.Path = epath.Path(__file__).parent
@@ -16,12 +14,12 @@ WHITE_ARENA_XML_PATH: epath.Path = CELEGANS_PATH / "xmls" / "white_arena.xml"
 REFERENCE_H5_PATH: epath.Path = CELEGANS_PATH / "reference_data" / "reference.h5"
 
 ROOT: str = "torso13_body"
-END_EFFECTORS: List[str] = [
+END_EFFECTORS: list[str] = [
     "torso1_body",
     "torso25_body",
 ]
-TOUCH_SENSORS: List[str] = []
-BODIES: List[str] = [
+TOUCH_SENSORS: list[str] = []
+BODIES: list[str] = [
     "torso1_body",
     "torso2_body",
     "torso3_body",
@@ -48,7 +46,7 @@ BODIES: List[str] = [
     "torso24_body",
     "torso25_body",
 ]
-JOINTS: List[str] = [
+JOINTS: list[str] = [
     "free_body_rot",
     "motor1_rot",
     "motor2_rot",
@@ -75,4 +73,4 @@ JOINTS: List[str] = [
     "rot24",
     "rot25",
 ]
-SENSORS: List[str] = ["accelerometer", "gyro", "velocimeter"]
+SENSORS: list[str] = ["accelerometer", "gyro", "velocimeter"]

--- a/vnl_playground/tasks/celegans/imitation.py
+++ b/vnl_playground/tasks/celegans/imitation.py
@@ -6,8 +6,9 @@ allows training agents to mimic reference motion clips.
 
 import collections
 import warnings
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple, Union
+from collections.abc import Callable, Mapping, Sequence
 from pprint import pformat
+from typing import Any
 
 import brax.math
 import jax
@@ -18,6 +19,7 @@ import numpy as np
 from ml_collections import config_dict
 from mujoco import mjx
 from mujoco_playground._src import mjx_env
+
 from vnl_playground.tasks.reference_clips import ReferenceClips
 from vnl_playground.tasks.reward_registry import RewardRegistry
 
@@ -96,10 +98,9 @@ class Imitation(worm_base.CelegansEnv):
     def __init__(
         self,
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[
-            Dict[str, Union[str, int, List[Any], Dict[str, Any]]]
-        ] = None,
-        clips: Optional[ReferenceClips] = None,
+        config_overrides: dict[str, str | int | list[Any] | dict[str, Any]]
+        | None = None,
+        clips: ReferenceClips | None = None,
     ) -> None:
         """Initialize the imitation environment.
 
@@ -193,7 +194,8 @@ class Imitation(worm_base.CelegansEnv):
         self._n_steps = int(self.ctrl_dt / self.sim_dt)
         if self._n_steps == 0:
             warnings.warn(
-                f"Simulation will not advance! Please increase `ctrl_dt` from {self.ctrl_dt} to at least {self.sim_dt}."
+                f"Simulation will not advance! Please increase `ctrl_dt` from {self.ctrl_dt} to at least {self.sim_dt}.",
+                stacklevel=2,
             )
 
         self._avg_episode_length = (
@@ -204,9 +206,10 @@ class Imitation(worm_base.CelegansEnv):
         self._default_render_camera = f"{self._config.render_camera}-worm"
         if self._default_render_camera not in self.camera_names:
             warnings.warn(
-                f"Camera {self._default_render_camera} not found in available cameras: {self.spec.camera_names}! (Hint: did you forget the suffix?)"
+                f"Camera {self._default_render_camera} not found in available cameras: {self.spec.camera_names}! (Hint: did you forget the suffix?)",
+                stacklevel=2,
             )
-            warnings.warn("Defaulting to camera: 'track-worm'")
+            warnings.warn("Defaulting to camera: 'track-worm'", stacklevel=2)
             self._default_render_camera = "track-worm"
 
     def __repr__(self) -> str:
@@ -241,8 +244,8 @@ class Imitation(worm_base.CelegansEnv):
     def reset(
         self,
         rng: jax.Array,
-        clip_idx: Optional[int] = None,
-        start_frame: Optional[int] = None,
+        clip_idx: int | None = None,
+        start_frame: int | None = None,
     ) -> mjx_env.State:
         """Reset the environment to initial state.
 
@@ -661,7 +664,11 @@ class Imitation(worm_base.CelegansEnv):
         return reward
 
     def _get_bodies_dist(
-        self, data: mjx.Data, info: Mapping[str, Any], metrics, bodies: List[str] = None
+        self,
+        data: mjx.Data,
+        info: Mapping[str, Any],
+        metrics,
+        bodies: list[str] | None = None,
     ) -> float:
         """Calculate distance between current and target body positions.
 
@@ -1011,7 +1018,7 @@ class Imitation(worm_base.CelegansEnv):
         return self._config.reference_length
 
     @property
-    def start_frame_range(self) -> Tuple[int, int]:
+    def start_frame_range(self) -> tuple[int, int]:
         """Get the range of valid start frames.
 
         Returns:
@@ -1020,7 +1027,7 @@ class Imitation(worm_base.CelegansEnv):
         return tuple(self._config.start_frame_range)
 
     @property
-    def reward_terms(self) -> Dict[str, Any]:
+    def reward_terms(self) -> dict[str, Any]:
         """Get the configured reward terms.
 
         Returns:
@@ -1029,7 +1036,7 @@ class Imitation(worm_base.CelegansEnv):
         return self._config.reward_terms
 
     @property
-    def cost_terms(self) -> Dict[str, Any]:
+    def cost_terms(self) -> dict[str, Any]:
         """Get the configured cost terms.
 
         Returns:
@@ -1038,7 +1045,7 @@ class Imitation(worm_base.CelegansEnv):
         return self._config.cost_terms
 
     @property
-    def termination_criteria(self) -> Dict[str, Any]:
+    def termination_criteria(self) -> dict[str, Any]:
         """Get the configured termination criteria.
 
         Returns:
@@ -1074,16 +1081,16 @@ class Imitation(worm_base.CelegansEnv):
 
     def render(
         self,
-        trajectory: List[mjx_env.State],
+        trajectory: list[mjx_env.State],
         height: int = 240,
         width: int = 320,
-        camera: Optional[str] = None,
-        scene_option: Optional[mujoco.MjvOption] = None,
-        modify_scene_fns: Optional[Sequence[Callable[[mujoco.MjvScene], None]]] = None,
+        camera: str | None = None,
+        scene_option: mujoco.MjvOption | None = None,
+        modify_scene_fns: Sequence[Callable[[mujoco.MjvScene], None]] | None = None,
         add_labels: bool = False,
         termination_extra_frames: int = 0,
         render_ghost: bool = True,
-        vid_path: Optional[str] = None,
+        vid_path: str | None = None,
     ) -> Sequence[np.ndarray]:
         """
         Renders a sequence of states (trajectory). The video includes the imitation
@@ -1126,7 +1133,6 @@ class Imitation(worm_base.CelegansEnv):
                 inplace=False,
             )
         else:
-            spec = self.spec
             mj_model_with_ghost = self.mj_model
 
         try:
@@ -1144,9 +1150,10 @@ class Imitation(worm_base.CelegansEnv):
             camera = -1
         elif camera not in available_cameras:
             warnings.warn(
-                f"Camera {camera} not found in available cameras: {available_cameras}! (Hint: did you forget the suffix?)"
+                f"Camera {camera} not found in available cameras: {available_cameras}! (Hint: did you forget the suffix?)",
+                stacklevel=2,
             )
-            warnings.warn("Defaulting to camera: 'track-worm'")
+            warnings.warn("Defaulting to camera: 'track-worm'", stacklevel=2)
             camera = "track-worm"
         print(f"Rendering with camera: {camera}")
         rendered_frames = []
@@ -1191,7 +1198,7 @@ class Imitation(worm_base.CelegansEnv):
                     reason = "<Unknown>"
                     if state.info["truncated"]:
                         reason = "truncated"
-                    for name in self.termination_criteria.keys():
+                    for name in self.termination_criteria:
                         if state.metrics[name] > 0:
                             reason = name
                     cv2.putText(
@@ -1224,10 +1231,10 @@ class Imitation(worm_base.CelegansEnv):
         rollout_source: Any,
         height: int = 480,
         width: int = 640,
-        camera: Optional[str] = None,
-        scene_option: Optional[mujoco.MjvOption] = None,
+        camera: str | None = None,
+        scene_option: mujoco.MjvOption | None = None,
         render_ghost: bool = True,
-    ) -> List[np.ndarray]:
+    ) -> list[np.ndarray]:
         """Render from precomputed qposes using the old track-mjx logic.
 
         Accepts either a rollout dictionary containing ``qposes_rollout`` and
@@ -1333,8 +1340,8 @@ class Imitation(worm_base.CelegansEnv):
             checks["joints"] = jp.allclose(
                 self._get_joint_angles(data), reference.joints, atol=atol
             )
-            body_pos = self._get_bodies_pos(data, flatten=False)
-            for body_name, body_pos in body_pos.items():
+            body_positions = self._get_bodies_pos(data, flatten=False)
+            for body_name, body_pos in body_positions.items():
                 checks[f"body_xpos/{body_name}"] = jp.allclose(
                     body_pos[: self._config.dim],
                     reference.body_xpos(body_name)[: self._config.dim],
@@ -1381,50 +1388,61 @@ class Imitation(worm_base.CelegansEnv):
                     warnings.warn(
                         f"Reference data verification failed for {n_failed} frames"
                         f" for check '{name}' for clip {clip}."
-                        f" First failure at frame {first_failed_frame}."
+                        f" First failure at frame {first_failed_frame}.",
+                        stacklevel=2,
                     )
                     if name == "root_pos":
                         warnings.warn(
-                            f"Root position: {self.root_body(data).xpos[: self._config.dim]} != {reference.body_xpos(self.root_name)[: self._config.dim]}"
+                            f"Root position: {self.root_body(data).xpos[: self._config.dim]} != {reference.body_xpos(self.root_name)[: self._config.dim]}",
+                            stacklevel=2,
                         )
                         warnings.warn(
-                            f"diff: {jp.linalg.norm(self.root_body(data).xpos[: self._config.dim] - reference.body_xpos(self.root_name)[: self._config.dim])}"
+                            f"diff: {jp.linalg.norm(self.root_body(data).xpos[: self._config.dim] - reference.body_xpos(self.root_name)[: self._config.dim])}",
+                            stacklevel=2,
                         )
                     elif name == "root_quat":
                         warnings.warn(
-                            f"Root quaternion: {self.root_body(data).xquat} != {reference.body_xquat(self.root_name)}"
+                            f"Root quaternion: {self.root_body(data).xquat} != {reference.body_xquat(self.root_name)}",
+                            stacklevel=2,
                         )
                         warnings.warn(
-                            f"diff: {jp.linalg.norm(self.root_body(data).xquat - reference.body_xquat(self.root_name))}"
+                            f"diff: {jp.linalg.norm(self.root_body(data).xquat - reference.body_xquat(self.root_name))}",
+                            stacklevel=2,
                         )
                     elif name == "joints":
                         warnings.warn(
-                            f"Joints: {self._get_joint_angles(data)} != {reference.joints}"
+                            f"Joints: {self._get_joint_angles(data)} != {reference.joints}",
+                            stacklevel=2,
                         )
                         warnings.warn(
-                            f"diff: {jp.linalg.norm(self._get_joint_angles(data) - reference.joints)}"
+                            f"diff: {jp.linalg.norm(self._get_joint_angles(data) - reference.joints)}",
+                            stacklevel=2,
                         )
                     elif name == "joints_ang_vel":
                         warnings.warn(
-                            f"Joints ang vel: {self._get_joint_ang_vels(data)} != {reference.joints_velocity}"
+                            f"Joints ang vel: {self._get_joint_ang_vels(data)} != {reference.joints_velocity}",
+                            stacklevel=2,
                         )
                         warnings.warn(
-                            f"diff: {jp.linalg.norm(self._get_joint_ang_vels(data) - reference.joints_velocity)}"
+                            f"diff: {jp.linalg.norm(self._get_joint_ang_vels(data) - reference.joints_velocity)}",
+                            stacklevel=2,
                         )
                     elif "body_xpos" in name:
                         body_name = name.split("/")[-1]
                         warnings.warn(
-                            f"Body {body_name} pos: {self._get_bodies_pos(data, flatten=False)[body_name][: self._config.dim]}(Sim) != {reference.body_xpos(body_name)[: self._config.dim]} (Ref)"
+                            f"Body {body_name} pos: {self._get_bodies_pos(data, flatten=False)[body_name][: self._config.dim]}(Sim) != {reference.body_xpos(body_name)[: self._config.dim]} (Ref)",
+                            stacklevel=2,
                         )
                         warnings.warn(
-                            f"diff: {jp.linalg.norm(self._get_bodies_pos(data, flatten=False)[body_name][: self._config.dim] - reference.body_xpos(body_name)[: self._config.dim])}"
+                            f"diff: {jp.linalg.norm(self._get_bodies_pos(data, flatten=False)[body_name][: self._config.dim] - reference.body_xpos(body_name)[: self._config.dim])}",
+                            stacklevel=2,
                         )
                     any_failed = True
         return not any_failed
 
 
 def _assert_all_are_prefix(
-    a: List[str], b: List[str], a_name: str = "a", b_name: str = "b"
+    a: list[str], b: list[str], a_name: str = "a", b_name: str = "b"
 ) -> None:
     """Assert that all elements in list a are prefixes of corresponding elements in list b.
 

--- a/vnl_playground/tasks/celegans/visualize.py
+++ b/vnl_playground/tasks/celegans/visualize.py
@@ -1,14 +1,13 @@
 """Celegans environment for visualization."""
 
-from vnl_playground.tasks.celegans import base as celegans_base
-from vnl_playground.tasks.celegans import consts
-
-from mujoco_playground._src import mjx_env
+from typing import Any
 
 import jax
 import jax.numpy as jp
 from ml_collections import config_dict
-from typing import Any, Dict, List, Optional, Union
+from mujoco_playground._src import mjx_env
+
+from vnl_playground.tasks.celegans import base as celegans_base
 
 
 class CelegansRender(celegans_base.CelegansEnv):
@@ -17,7 +16,7 @@ class CelegansRender(celegans_base.CelegansEnv):
     def __init__(
         self,
         config: config_dict.ConfigDict = celegans_base.default_config(),
-        config_override: Optional[Dict[str, Union[str, int, List[Any]]]] = None,
+        config_override: dict[str, str | int | list[Any]] | None = None,
     ):
         super().__init__(config, config_override)
 

--- a/vnl_playground/tasks/fruitfly/base.py
+++ b/vnl_playground/tasks/fruitfly/base.py
@@ -1,24 +1,24 @@
 """Base classes for fruitfly"""
 
 import collections
-from typing import Any, Dict, Mapping, Optional, Union
+import logging
+from collections.abc import Mapping
+from typing import Any
 
-from etils import epath
 import jax
 import jax.numpy as jp
-import logging
+import mujoco
 import numpy as np
 from ml_collections import config_dict
-import mujoco
 from mujoco import mjx
-
 from mujoco_playground._src import mjx_env
+
 from vnl_playground.tasks.fruitfly import consts
-from vnl_playground.tasks.utils import _scale_body_tree, _recolour_tree, scale_spec
 from vnl_playground.tasks.reward_registry import RewardRegistry
+from vnl_playground.tasks.utils import _recolour_tree, _scale_body_tree, scale_spec
 
 
-def get_assets() -> Dict[str, bytes]:
+def get_assets() -> dict[str, bytes]:
     assets = {}
     mjx_env.update_assets(assets, consts.FRUITFLY_PATH / "xmls", "*.xml")
     mjx_env.update_assets(assets, consts.FRUITFLY_PATH / "xmls" / "assets")
@@ -52,7 +52,7 @@ class FruitflyEnv(mjx_env.MjxEnv):
     def __init__(
         self,
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any]]]] = None,
+        config_overrides: dict[str, str | int | list[Any]] | None = None,
     ) -> None:
         """
         Initialize the FruitflyEnv class with only arena
@@ -74,7 +74,7 @@ class FruitflyEnv(mjx_env.MjxEnv):
         rescale_factor: float = 1.0,
         pos: tuple[float, float, float] = (0, 0, 0.05),
         quat: tuple[float, float, float, float] = (1, 0, 0, 0),
-        rgba: Optional[tuple[float, float, float, float]] = None,
+        rgba: tuple[float, float, float, float] | None = None,
         suffix: str = "-fly",
     ) -> None:
         """Adds the fly model to the environment.
@@ -90,7 +90,7 @@ class FruitflyEnv(mjx_env.MjxEnv):
         """
         fly = mujoco.MjSpec.from_file(self._walker_xml_path)
 
-        # a) Convert motors to torque‑mode if requested
+        # a) Convert motors to torque-mode if requested
         if torque_actuators and hasattr(fly, "actuator"):
             logging.info("Converting to torque actuators")
             for actuator in fly.actuators:  # type: ignore[attr-defined]
@@ -115,7 +115,7 @@ class FruitflyEnv(mjx_env.MjxEnv):
             quat=quat,
         )
 
-        spawn_body = spawn_frame.attach_body(fly.body("thorax"), "", suffix=suffix)
+        spawn_frame.attach_body(fly.body("thorax"), "", suffix=suffix)
         self._suffix = suffix
 
     def add_ghost_fly(
@@ -133,7 +133,7 @@ class FruitflyEnv(mjx_env.MjxEnv):
             _recolour_tree(body, rgba=ghost_rgba)
         # Attach as ghost at the offset frame
         spawn_frame = self._spec.worldbody.add_frame(pos=pos, quat=[1, 0, 0, 0])
-        spawn_body = spawn_frame.attach_body(fly_spec.body("thorax"), "", suffix=suffix)
+        spawn_frame.attach_body(fly_spec.body("thorax"), "", suffix=suffix)
 
     def compile(self, forced=False) -> None:
         """Compiles the model from the mj_spec and put models to mjx"""
@@ -162,7 +162,7 @@ class FruitflyEnv(mjx_env.MjxEnv):
 
     def _get_appendages_pos(
         self, data: mjx.Data, flatten: bool = True
-    ) -> Union[dict[str, jp.ndarray], jp.ndarray]:
+    ) -> dict[str, jp.ndarray] | jp.ndarray:
         """Get _egocentric_ position of the appendages (claws)."""
         thorax = data.bind(self.mjx_model, self._spec.body(f"thorax{self._suffix}"))
         appendages_pos = collections.OrderedDict()
@@ -178,7 +178,7 @@ class FruitflyEnv(mjx_env.MjxEnv):
 
     def _get_bodies_pos(
         self, data: mjx.Data, flatten: bool = True
-    ) -> Union[dict[str, jp.ndarray], jp.ndarray]:
+    ) -> dict[str, jp.ndarray] | jp.ndarray:
         """Get _global_ positions of the body parts."""
         bodies_pos = collections.OrderedDict()
         for body_name in consts.BODIES:
@@ -221,7 +221,7 @@ class FruitflyEnv(mjx_env.MjxEnv):
 
     def _get_proprioception(
         self, data: mjx.Data, info: Mapping[str, Any], flatten: bool = True
-    ) -> Union[jp.ndarray, Mapping[str, jp.ndarray]]:
+    ) -> jp.ndarray | Mapping[str, jp.ndarray]:
         """Get proprioception data from the environment."""
         proprioception = collections.OrderedDict(
             joint_angles=self._get_joint_angles(data),
@@ -239,7 +239,7 @@ class FruitflyEnv(mjx_env.MjxEnv):
 
     def _get_kinematic_sensors(
         self, data: mjx.Data, flatten: bool = True
-    ) -> Union[Mapping[str, jp.ndarray], jp.ndarray]:
+    ) -> Mapping[str, jp.ndarray] | jp.ndarray:
         """Get kinematic sensors data from the environment."""
         accelerometer = data.bind(
             self.mjx_model, self._spec.sensor(f"accelerometer{self._suffix}")

--- a/vnl_playground/tasks/fruitfly/consts.py
+++ b/vnl_playground/tasks/fruitfly/consts.py
@@ -2,8 +2,6 @@
 
 from etils import epath
 
-from mujoco_playground._src import mjx_env
-
 FRUITFLY_PATH = epath.Path(__file__).parent
 
 FRUITFLY_XML_PATH = FRUITFLY_PATH / "xmls" / "fruitfly_fast.xml"
@@ -19,7 +17,7 @@ IMITATION_REFERENCE_PATH = (
     / "fly_reference_clip.h5"
 )
 
-# 36 joints (6 per leg × 3 legs × 2 sides)
+# 36 joints (6 per leg x 3 legs x 2 sides)
 JOINTS = [
     # T1 left
     "coxa_flexion_T1_left",
@@ -65,7 +63,7 @@ JOINTS = [
     "tarsus_T3_right",
 ]
 
-# 48 bodies (8 segments per leg × 6 legs)
+# 48 bodies (8 segments per leg x 6 legs)
 BODIES = [
     # T1 left
     "coxa_T1_left",

--- a/vnl_playground/tasks/fruitfly/imitation.py
+++ b/vnl_playground/tasks/fruitfly/imitation.py
@@ -1,8 +1,8 @@
 """Fruitfly multi-clip imitation environment."""
 
 import collections
-import warnings
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
 
 import brax.math
 import jax
@@ -12,13 +12,13 @@ import numpy as np
 from ml_collections import config_dict
 from mujoco import mjx
 from mujoco_playground._src import mjx_env
-from jax import flatten_util
+
+from vnl_playground.tasks.reference_clips import ReferenceClips
+from vnl_playground.tasks.reward_registry import RewardRegistry
 
 from .. import utils
 from . import base as fruitfly_base
 from . import consts
-from vnl_playground.tasks.reference_clips import ReferenceClips
-from vnl_playground.tasks.reward_registry import RewardRegistry
 
 _registry = RewardRegistry()
 
@@ -87,8 +87,8 @@ class Imitation(fruitfly_base.FruitflyEnv):
     def __init__(
         self,
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any], dict]]] = None,
-        clips: Optional[ReferenceClips] = None,
+        config_overrides: dict[str, str | int | list[Any] | dict] | None = None,
+        clips: ReferenceClips | None = None,
     ) -> None:
         """
         Initialize the fruitfly imitation environment.
@@ -133,8 +133,8 @@ class Imitation(fruitfly_base.FruitflyEnv):
     def reset(
         self,
         rng: jax.Array,
-        clip_idx: Optional[int] = None,
-        start_frame: Optional[int] = None,
+        clip_idx: int | None = None,
+        start_frame: int | None = None,
     ) -> mjx_env.State:
         """
         Resets the environment state.
@@ -437,12 +437,12 @@ class Imitation(fruitfly_base.FruitflyEnv):
 
     def render(
         self,
-        trajectory: List[mjx_env.State],
+        trajectory: list[mjx_env.State],
         height: int = 240,
         width: int = 320,
-        camera: Optional[str] = None,
-        scene_option: Optional[mujoco.MjvOption] = None,
-        modify_scene_fns: Optional[Sequence[Callable[[mujoco.MjvScene], None]]] = None,
+        camera: str | None = None,
+        scene_option: mujoco.MjvOption | None = None,
+        modify_scene_fns: Sequence[Callable[[mujoco.MjvScene], None]] | None = None,
         add_labels=False,
         termination_extra_frames=0,
     ) -> Sequence[np.ndarray]:
@@ -490,9 +490,7 @@ class Imitation(fruitfly_base.FruitflyEnv):
             disable_collision_recursive(body)
 
         spawn_frame = spec.worldbody.add_frame(pos=(0, 0, 0.0), quat=(1, 0, 0, 0))
-        spawn_body = spawn_frame.attach_body(
-            ghost_fly.body("thorax"), "", suffix="-ghost"
-        )
+        spawn_frame.attach_body(ghost_fly.body("thorax"), "", suffix="-ghost")
 
         mj_model_with_ghost = spec.compile()
         mj_model_with_ghost.vis.global_.offwidth = width
@@ -534,29 +532,28 @@ class Imitation(fruitfly_base.FruitflyEnv):
                     cv2.LINE_AA,
                 )
             rendered_frames.append(rendered_frame)
-            if state.done:
-                if add_labels:
-                    import cv2
+            if state.done and add_labels:
+                import cv2
 
-                    reason = "<Unknown>"
-                    if state.info["truncated"]:
-                        reason = "truncated"
-                    for name in self._config.termination_criteria.keys():
-                        if state.metrics["terminations/" + name] > 0:
-                            reason = name
-                    cv2.putText(
-                        rendered_frame,
-                        reason,
-                        (10, 70),
-                        cv2.FONT_HERSHEY_SIMPLEX,
-                        1.0,
-                        (255, 255, 255),
-                        2,
-                        cv2.LINE_AA,
-                    )
-                    for t in range(termination_extra_frames):
-                        rel_t = t / termination_extra_frames
-                        fade_factor = 1 / (1 + np.exp(10 * (rel_t - 0.5)))
-                        faded_frame = (rendered_frame * fade_factor).astype(np.uint8)
-                        rendered_frames.append(faded_frame)
+                reason = "<Unknown>"
+                if state.info["truncated"]:
+                    reason = "truncated"
+                for name in self._config.termination_criteria:
+                    if state.metrics["terminations/" + name] > 0:
+                        reason = name
+                cv2.putText(
+                    rendered_frame,
+                    reason,
+                    (10, 70),
+                    cv2.FONT_HERSHEY_SIMPLEX,
+                    1.0,
+                    (255, 255, 255),
+                    2,
+                    cv2.LINE_AA,
+                )
+                for t in range(termination_extra_frames):
+                    rel_t = t / termination_extra_frames
+                    fade_factor = 1 / (1 + np.exp(10 * (rel_t - 0.5)))
+                    faded_frame = (rendered_frame * fade_factor).astype(np.uint8)
+                    rendered_frames.append(faded_frame)
         return rendered_frames

--- a/vnl_playground/tasks/fruitfly/maintain_velocity.py
+++ b/vnl_playground/tasks/fruitfly/maintain_velocity.py
@@ -11,15 +11,13 @@ Termination occurs if:
 """
 
 import collections
-from typing import Any, Dict, Mapping, Optional, Union
+from typing import Any
 
 import jax
 import jax.numpy as jp
 import numpy as np
-from jax import flatten_util
 from ml_collections import config_dict
 from mujoco import mjx
-
 from mujoco_playground._src import mjx_env
 from mujoco_playground._src import reward as reward_fns
 
@@ -73,7 +71,7 @@ class MaintainVelocity(fruitfly_base.FruitflyEnv):
         self,
         rng: jax.Array = jax.random.PRNGKey(0),
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any]]]] = None,
+        config_overrides: dict[str, str | int | list[Any]] | None = None,
     ) -> None:
         super().__init__(config, config_overrides)
         self._rng = rng

--- a/vnl_playground/tasks/fruitfly/visualize.py
+++ b/vnl_playground/tasks/fruitfly/visualize.py
@@ -1,14 +1,11 @@
-from vnl_playground.tasks.fruitfly import base as fly_base
-from vnl_playground.tasks.fruitfly import consts
-
-from mujoco_playground._src import mjx_env
-
 import jax
 import jax.numpy as jp
+from mujoco_playground._src import mjx_env
+
+from vnl_playground.tasks.fruitfly import base as fly_base
 
 
 class FlyRender(fly_base.FruitflyEnv):
-
     def reset(self, rng: jax.Array) -> mjx_env.State:
         data = mjx_env.init(self.mjx_model)
         reward, done, obs = jp.zeros(3)

--- a/vnl_playground/tasks/mouse/base.py
+++ b/vnl_playground/tasks/mouse/base.py
@@ -1,20 +1,21 @@
 """Base classes for mouse (arena-first, add walker later)."""
 
-from typing import Any, Dict, Mapping, Optional, Union
+from collections.abc import Mapping
+from typing import Any
 
 import jax
 import jax.numpy as jp
-from ml_collections import config_dict
 import mujoco
+from ml_collections import config_dict
 from mujoco import mjx
+from mujoco_playground._src import mjx_env
 from tqdm import tqdm
 
-from mujoco_playground._src import mjx_env
 from vnl_playground.tasks.mouse import consts
 from vnl_playground.tasks.reward_registry import RewardRegistry
 
 
-def get_assets() -> Dict[str, bytes]:
+def get_assets() -> dict[str, bytes]:
     """Collect XML + asset files into a dict for bundling/remote loading.
 
     Returns:
@@ -58,7 +59,7 @@ class MouseBaseEnv(mjx_env.MjxEnv):
     def __init__(
         self,
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any]]]] = None,
+        config_overrides: dict[str, str | int | list[Any]] | None = None,
     ) -> None:
         """
         Initialize with arena-only MjSpec; add mouse(s) later via add_mouse().
@@ -78,9 +79,9 @@ class MouseBaseEnv(mjx_env.MjxEnv):
     def add_mouse(
         self,
         freejoint: bool = False,
-        pos: Union[tuple[float, float, float], list[float]] = (0.0, 0.0, 0.02),
+        pos: tuple[float, float, float] | list[float] = (0.0, 0.0, 0.02),
         suffix: str = "-mouse",
-        rgba: Optional[tuple[float, float, float, float]] = None,
+        rgba: tuple[float, float, float, float] | None = None,
     ) -> None:
         """
         Attach a mouse model to the arena at the given position.
@@ -112,7 +113,7 @@ class MouseBaseEnv(mjx_env.MjxEnv):
 
     def add_ghost_mouse(
         self,
-        pos: Union[tuple[float, float, float], list[float]] = (0.2, 0.0, 0.02),
+        pos: tuple[float, float, float] | list[float] = (0.2, 0.0, 0.02),
         suffix: str = "-ghost",
         ghost_rgba: tuple[float, float, float, float] = (
             65 / 256,

--- a/vnl_playground/tasks/mouse/imitation.py
+++ b/vnl_playground/tasks/mouse/imitation.py
@@ -1,13 +1,13 @@
 """Mouse arm imitation environment for motion tracking."""
 
 import collections
-from typing import Any, Dict, List, Mapping, Optional, Sequence, Union
+from collections.abc import Mapping, Sequence
+from typing import Any
 
 import jax
 import jax.numpy as jp
 import mujoco
 import numpy as np
-from jax import flatten_util
 from ml_collections import config_dict
 from mujoco import mjx
 from mujoco_playground._src import mjx_env
@@ -15,6 +15,8 @@ from mujoco_playground._src import mjx_env
 from vnl_playground.tasks.mouse import consts
 from vnl_playground.tasks.mouse.base import (
     MouseBaseEnv,
+)
+from vnl_playground.tasks.mouse.base import (
     default_config as base_default_config,
 )
 from vnl_playground.tasks.mouse.reference_clips import MouseReferenceClips
@@ -73,8 +75,8 @@ class MouseImitation(MouseBaseEnv):
     def __init__(
         self,
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any], dict]]] = None,
-        clips: Optional[MouseReferenceClips] = None,
+        config_overrides: dict[str, str | int | list[Any] | dict] | None = None,
+        clips: MouseReferenceClips | None = None,
     ) -> None:
         """Initialize the mouse arm imitation environment.
 
@@ -129,8 +131,8 @@ class MouseImitation(MouseBaseEnv):
     def reset(
         self,
         rng: jax.Array,
-        clip_idx: Optional[int] = None,
-        start_frame: Optional[int] = None,
+        clip_idx: int | None = None,
+        start_frame: int | None = None,
     ) -> mjx_env.State:
         """Reset the environment to a reference pose.
 
@@ -537,11 +539,11 @@ class MouseImitation(MouseBaseEnv):
 
     def render(
         self,
-        trajectory: List[mjx_env.State],
+        trajectory: list[mjx_env.State],
         height: int = 480,
         width: int = 640,
-        camera: Optional[str] = None,
-        scene_option: Optional[mujoco.MjvOption] = None,
+        camera: str | None = None,
+        scene_option: mujoco.MjvOption | None = None,
         render_ghost: bool = True,
     ) -> Sequence[np.ndarray]:
         """Render a trajectory with optional ghost showing reference motion.

--- a/vnl_playground/tasks/mouse/mouse_reach.py
+++ b/vnl_playground/tasks/mouse/mouse_reach.py
@@ -1,19 +1,21 @@
 """Mouse forelimb reaching task following rodent task patterns."""
 
 import collections
-from typing import Any, Dict, Mapping, Optional, Union
+from collections.abc import Mapping
+from typing import Any
 
 import jax
 import jax.numpy as jp
-from ml_collections import config_dict
 import mujoco
+from ml_collections import config_dict
 from mujoco import mjx
-
-from jax import flatten_util
 from mujoco_playground._src import mjx_env
 from mujoco_playground._src import reward as reward_fns
+
 from vnl_playground.tasks.mouse.base import (
     MouseBaseEnv,
+)
+from vnl_playground.tasks.mouse.base import (
     default_config as base_default_config,
 )
 from vnl_playground.tasks.reward_registry import RewardRegistry
@@ -56,7 +58,7 @@ class MouseReach(MouseBaseEnv):
     def __init__(
         self,
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any]]]] = None,
+        config_overrides: dict[str, str | int | list[Any]] | None = None,
     ) -> None:
         """Initialize the mouse reaching environment.
 

--- a/vnl_playground/tasks/mouse/reference_clips.py
+++ b/vnl_playground/tasks/mouse/reference_clips.py
@@ -3,7 +3,7 @@
 import copy
 import glob
 import os
-from typing import List, Optional, TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import h5py
 import jax
@@ -24,13 +24,13 @@ class MouseReferenceClips:
     the fixed-base arm structure (no root freejoint).
     """
 
-    _DATA_ARRAYS = ["qpos", "qvel", "xpos", "xquat"]
+    _DATA_ARRAYS: ClassVar[list[str]] = ["qpos", "qvel", "xpos", "xquat"]
 
     def __init__(
         self,
         data_path: str,
-        n_frames_per_clip: Optional[int] = None,
-        keep_clips_idx: Optional[List[int]] = None,
+        n_frames_per_clip: int | None = None,
+        keep_clips_idx: list[int] | None = None,
     ):
         """Load reference clips from a directory of h5 files.
 
@@ -44,9 +44,7 @@ class MouseReferenceClips:
         self._n_frames_per_clip = n_frames_per_clip
         self._load_from_disk(data_path, keep_clips_idx)
 
-    def _load_from_disk(
-        self, data_path: str, keep_clips_idx: Optional[List[int]] = None
-    ):
+    def _load_from_disk(self, data_path: str, keep_clips_idx: list[int] | None = None):
         """Load all h5 files from the directory into stacked JAX arrays.
 
         Args:

--- a/vnl_playground/tasks/mouse/visualize.py
+++ b/vnl_playground/tasks/mouse/visualize.py
@@ -1,7 +1,8 @@
-from vnl_playground.tasks.mouse.mouse_reach import MouseEnv
-from mujoco_playground._src import mjx_env
 import jax
 import jax.numpy as jp
+from mujoco_playground._src import mjx_env
+
+from vnl_playground.tasks.mouse.mouse_reach import MouseEnv
 
 
 class MouseRender(MouseEnv):

--- a/vnl_playground/tasks/reference_clips.py
+++ b/vnl_playground/tasks/reference_clips.py
@@ -29,12 +29,12 @@ Usage
 ... )
 >>>
 >>> # Access data using consistent API
->>> clips.qpos.shape        # (n_clips, n_frames, n_dof)
->>> clips.joints.shape      # (n_clips, n_frames, n_joints)
->>> clips.root_position     # (n_clips, n_frames, 3)
+>>> clips.qpos.shape  # (n_clips, n_frames, n_dof)
+>>> clips.joints.shape  # (n_clips, n_frames, n_joints)
+>>> clips.root_position  # (n_clips, n_frames, 3)
 >>>
 >>> # Slice operations
->>> frame = clips.at(clip=0, frame=10)      # Single frame
+>>> frame = clips.at(clip=0, frame=10)  # Single frame
 >>> seq = clips.slice(clip=0, start_frame=0, length=50)  # Frame sequence
 >>>
 >>> # Train/test split
@@ -47,17 +47,18 @@ See Also
 """
 
 import copy
+import logging
 import re
+import warnings
+from collections.abc import Mapping
 from ctypes import Array
-from typing import Any, Mapping, Optional, List, Tuple
+from typing import Any, ClassVar
 
 import h5py
 import jax
 import jax.numpy as jp
 import numpy as np
 import yaml
-import logging
-import warnings
 
 
 class ReferenceClips:
@@ -106,7 +107,7 @@ class ReferenceClips:
     """
 
     # Named-array format keys
-    _NAMED_ARRAYS = [
+    _NAMED_ARRAYS: ClassVar[list[str]] = [
         "position",
         "velocity",
         "quaternion",
@@ -118,15 +119,15 @@ class ReferenceClips:
     ]
 
     # Legacy flat-array format keys
-    _LEGACY_ARRAYS = ["qpos", "qvel", "xpos", "xquat"]
+    _LEGACY_ARRAYS: ClassVar[list[str]] = ["qpos", "qvel", "xpos", "xquat"]
 
     def __init__(
         self,
         data_path: str,
         n_frames_per_clip: int,
-        keep_clips_idx: Optional[Array[int]] = None,
-        joint_names: Optional[list[str]] = None,
-        body_names: Optional[list[str]] = None,
+        keep_clips_idx: Array[int] | None = None,
+        joint_names: list[str] | None = None,
+        body_names: list[str] | None = None,
     ):
         """Load reference clips from an HDF5 file.
 
@@ -160,8 +161,8 @@ class ReferenceClips:
         self._joint_names_list: list[str] = []
         self._body_names_map: dict[str, int] = {}
         self._is_legacy_format = False
-        self._config: Optional[dict] = None
-        self.clip_names: Optional[np.ndarray] = None
+        self._config: dict | None = None
+        self.clip_names: np.ndarray | None = None
 
         self._load_from_disk(
             data_path, n_frames_per_clip, keep_clips_idx, joint_names, body_names
@@ -182,9 +183,9 @@ class ReferenceClips:
         self,
         data_path: str,
         n_frames_per_clip: int,
-        keep_clips_idx: Optional[Array[int]],
-        joint_names: Optional[list[str]],
-        body_names: Optional[list[str]],
+        keep_clips_idx: Array[int] | None,
+        joint_names: list[str] | None,
+        body_names: list[str] | None,
     ) -> None:
         """Load data from H5 file, auto-detecting format.
 
@@ -198,7 +199,7 @@ class ReferenceClips:
         self._data_path = data_path
         with h5py.File(data_path, "r") as fid:
             # Detect format by checking for named arrays
-            group = fid["all_clips"] if "all_clips" in fid else fid
+            group = fid.get("all_clips", fid)
 
             if "joints" in group or "position" in group:
                 self._load_named_format(
@@ -213,9 +214,9 @@ class ReferenceClips:
         self,
         fid: h5py.File,
         group: h5py.Group,
-        keep_clips_idx: Optional[Array[int]],
-        joint_names: Optional[list[str]],
-        body_names: Optional[list[str]],
+        keep_clips_idx: Array[int] | None,
+        joint_names: list[str] | None,
+        body_names: list[str] | None,
     ) -> None:
         """Load named-array format (fruitfly-style)."""
         self._is_legacy_format = False
@@ -254,9 +255,9 @@ class ReferenceClips:
         self,
         fid: h5py.File,
         n_frames_per_clip: int,
-        keep_clips_idx: Optional[Array[int]],
-        joint_names: Optional[list[str]],
-        body_names: Optional[list[str]],
+        keep_clips_idx: Array[int] | None,
+        joint_names: list[str] | None,
+        body_names: list[str] | None,
     ) -> None:
         """Load legacy flat-array format (rodent-style)."""
         self._is_legacy_format = True
@@ -298,7 +299,7 @@ class ReferenceClips:
             else:
                 self._body_names_map = {n: i for (i, n) in enumerate(names_xpos)}
 
-    def _extract_clip_names(self, config: Mapping[str, Any]) -> Optional[np.ndarray]:
+    def _extract_clip_names(self, config: Mapping[str, Any]) -> np.ndarray | None:
         """Extract behavior names from legacy config metadata."""
         if "model" not in config or "snips_order" not in config.get("model", {}):
             return None
@@ -438,7 +439,8 @@ class ReferenceClips:
 
         if n_clips == n_train:
             warnings.warn(
-                "train_ratio results in empty test set; using full dataset for both."
+                "train_ratio results in empty test set; using full dataset for both.",
+                stacklevel=2,
             )
             logging.info(f"Training clips: {n_train}; Test clips: {n_train}")
             return copy.copy(self), copy.copy(self)
@@ -651,7 +653,7 @@ class ReferenceClips:
         return self._clip_idx
 
     @property
-    def shape(self) -> Tuple[int, ...]:
+    def shape(self) -> tuple[int, ...]:
         """Get the shape of the motion data.
 
         Returns:
@@ -669,7 +671,7 @@ class ReferenceClips:
         return self.qpos.ndim < 3
 
     @property
-    def joint_indices(self) -> List[int]:
+    def joint_indices(self) -> list[int]:
         """Get indices of joints.
 
         Returns:

--- a/vnl_playground/tasks/reward_registry.py
+++ b/vnl_playground/tasks/reward_registry.py
@@ -1,6 +1,6 @@
 """Registry for reward and termination functions."""
 
-from typing import Callable
+from collections.abc import Callable
 
 
 class RewardRegistry:

--- a/vnl_playground/tasks/rodent/base.py
+++ b/vnl_playground/tasks/rodent/base.py
@@ -1,25 +1,25 @@
 """Base classes for rodent"""
 
-from typing import Any, Dict, Optional, Union, Mapping
 import collections
-
-from etils import epath
 import logging
+from collections.abc import Mapping
+from typing import Any
+
 import jax
 import jax.numpy as jp
-import mujoco_playground
-import numpy as np
-from ml_collections import config_dict
 import mujoco
+import numpy as np
+from etils import epath
+from ml_collections import config_dict
 from mujoco import mjx
-
 from mujoco_playground._src import mjx_env
-from vnl_playground.tasks.rodent import consts
-from vnl_playground.tasks.utils import _scale_body_tree, _recolour_tree, scale_spec
+
 from vnl_playground.tasks.reward_registry import RewardRegistry
+from vnl_playground.tasks.rodent import consts
+from vnl_playground.tasks.utils import _recolour_tree, _scale_body_tree, scale_spec
 
 
-def get_assets() -> Dict[str, bytes]:
+def get_assets() -> dict[str, bytes]:
     assets = {}
     mjx_env.update_assets(assets, consts.RODENT_PATH / "xmls", "*.xml")
     mjx_env.update_assets(assets, consts.RODENT_PATH / "xmls" / "assets")
@@ -54,7 +54,7 @@ class RodentEnv(mjx_env.MjxEnv):
     def __init__(
         self,
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any]]]] = None,
+        config_overrides: dict[str, str | int | list[Any]] | None = None,
     ) -> None:
         """
         Initialize the RodentEnv class with only arena
@@ -76,7 +76,7 @@ class RodentEnv(mjx_env.MjxEnv):
         rescale_factor: float = 1.0,
         pos: tuple[float, float, float] = (0, 0, 0),
         quat: tuple[float, float, float, float] = (1, 0, 0, 0),
-        rgba: Optional[tuple[float, float, float, float]] = None,
+        rgba: tuple[float, float, float, float] | None = None,
         suffix: str = "-rodent",
     ) -> None:
         """Adds the rodent model to the environment.
@@ -92,7 +92,7 @@ class RodentEnv(mjx_env.MjxEnv):
         """
         rodent = mujoco.MjSpec.from_file(self._walker_xml_path)
 
-        # a) Convert motors to torque‑mode if requested
+        # a) Convert motors to torque-mode if requested
         if torque_actuators and hasattr(rodent, "actuator"):
             logging.info("Converting to torque actuators")
             for actuator in rodent.actuators:  # type: ignore[attr-defined]
@@ -174,7 +174,7 @@ class RodentEnv(mjx_env.MjxEnv):
 
     def _get_appendages_pos(
         self, data: mjx.Data, flatten: bool = True
-    ) -> Union[dict[str, jp.ndarray], jp.ndarray]:
+    ) -> dict[str, jp.ndarray] | jp.ndarray:
         """Get _egocentric_ position of the appendages."""
         torso = data.bind(self.mjx_model, self._spec.body(f"torso{self._suffix}"))
         appendages_pos = collections.OrderedDict()
@@ -190,7 +190,7 @@ class RodentEnv(mjx_env.MjxEnv):
 
     def _get_bodies_pos(
         self, data: mjx.Data, flatten: bool = True
-    ) -> Union[dict[str, jp.ndarray], jp.ndarray]:
+    ) -> dict[str, jp.ndarray] | jp.ndarray:
         """Get _global_ positions of the body parts."""
         bodies_pos = collections.OrderedDict()
         for body_name in consts.BODIES:
@@ -227,7 +227,7 @@ class RodentEnv(mjx_env.MjxEnv):
 
     def _get_proprioception(
         self, data: mjx.Data, info: Mapping[str, Any], flatten: bool = True
-    ) -> Union[jp.ndarray, Mapping[str, jp.ndarray]]:
+    ) -> jp.ndarray | Mapping[str, jp.ndarray]:
         """Get proprioception data from the environment."""
         proprioception = collections.OrderedDict(
             joint_angles=self._get_joint_angles(data),
@@ -246,7 +246,7 @@ class RodentEnv(mjx_env.MjxEnv):
 
     def _get_kinematic_sensors(
         self, data: mjx.Data, flatten: bool = True
-    ) -> Union[Mapping[str, jp.ndarray], jp.ndarray]:
+    ) -> Mapping[str, jp.ndarray] | jp.ndarray:
         """Get kinematic sensors data from the environment."""
         accelerometer = data.bind(
             self.mjx_model, self._spec.sensor(f"accelerometer{self._suffix}")

--- a/vnl_playground/tasks/rodent/bowl_escape.py
+++ b/vnl_playground/tasks/rodent/bowl_escape.py
@@ -1,28 +1,23 @@
 # Bowl escape definition, reflecting the mujoco playgrounds.
 import collections
-from typing import Any, Dict, Mapping, Optional, Union, Tuple, Callable
-import jax.flatten_util
-import numpy as np
-from scipy.spatial.transform import Rotation
+from collections.abc import Callable
+from typing import Any
 
-from etils import epath
 import jax
+import jax.flatten_util
 import jax.numpy as jp
+import matplotlib.colors as mcolors
+import mujoco
 import numpy as np
 from ml_collections import config_dict
-import mujoco
 from mujoco import mjx
-import warnings
-from jax import flatten_util
-
 from mujoco_playground._src import mjx_env
 from mujoco_playground._src import reward as reward_fns
+from scipy.spatial.transform import Rotation
 
+from vnl_playground.tasks.reward_registry import RewardRegistry
 from vnl_playground.tasks.rodent import base as rodent_base
 from vnl_playground.tasks.rodent import consts
-from vnl_playground.tasks.reward_registry import RewardRegistry
-
-import matplotlib.colors as mcolors
 
 _registry = RewardRegistry()
 
@@ -107,7 +102,7 @@ class BowlEscape(rodent_base.RodentEnv):
         self,
         rng: jax.Array = jax.random.PRNGKey(0),
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any]]]] = None,
+        config_overrides: dict[str, str | int | list[Any]] | None = None,
     ) -> None:
         """
         Initialize the BowlEscape class and set up the environment.
@@ -441,8 +436,8 @@ class BowlEscapeRender(BowlEscape):
         num_rodents: int = 1,
         rng: jax.Array = jax.random.PRNGKey(0),
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any]]]] = None,
-        line_coords: Optional[list[tuple[float, float, float]]] = None,
+        config_overrides: dict[str, str | int | list[Any]] | None = None,
+        line_coords: list[tuple[float, float, float]] | None = None,
         line_radius: float = 0.002,
     ) -> None:
         """Initialize the BowlEscapeRender class with rendering capabilities.
@@ -493,7 +488,7 @@ class BowlEscapeRender(BowlEscape):
         self._base_geom_count = len(self._spec.worldbody.geoms)
 
     def add_line_geoms(
-        self, line_coords: Optional[list[tuple[float, float, float]]] = None
+        self, line_coords: list[tuple[float, float, float]] | None = None
     ) -> None:
         """Add sphere geoms for each coordinate in self.line_coords."""
         if line_coords is None:
@@ -548,9 +543,9 @@ def interpolant(t: jp.ndarray) -> jp.ndarray:
 
 def perlin(
     rng: jax.Array,
-    shape: Tuple[int, int],
-    res: Tuple[int, int],
-    tileable: Tuple[bool, bool] = (False, False),
+    shape: tuple[int, int],
+    res: tuple[int, int],
+    tileable: tuple[bool, bool] = (False, False),
     interpolant: Callable[[jp.ndarray], jp.ndarray] = interpolant,
 ) -> np.ndarray:
     """Generate a 2D numpy array of Perlin noise.
@@ -596,7 +591,7 @@ def perlin(
 
 
 def gaussian_bowl(
-    shape: Tuple[int, int], sigma: float = 0.5, amplitude: float = -5.0
+    shape: tuple[int, int], sigma: float = 0.5, amplitude: float = -5.0
 ) -> np.ndarray:
     """Generate a Gaussian bowl shape.
 
@@ -616,12 +611,12 @@ def gaussian_bowl(
 
 def add_bowl_hfield(
     rng: jax.Array,
-    spec: Optional[mujoco.MjSpec] = None,
+    spec: mujoco.MjSpec | None = None,
     hsize: float = 10,
     vsize: float = 4,
     sigma: float = 0.5,
     amplitude: float = -5.0,
-) -> Tuple[mujoco.MjSpec, np.ndarray]:
+) -> tuple[mujoco.MjSpec, np.ndarray]:
     """Add a noisy bowl height field to the Mujoco spec.
 
     Args:
@@ -670,7 +665,7 @@ def add_bowl_hfield(
     noise /= np.max(noise)
 
     # Create height field
-    hfield = spec.add_hfield(
+    spec.add_hfield(
         name="hfield",
         size=[hsize, hsize, vsize, vsize],
         nrow=noise.shape[0],

--- a/vnl_playground/tasks/rodent/consts.py
+++ b/vnl_playground/tasks/rodent/consts.py
@@ -2,8 +2,6 @@
 
 from etils import epath
 
-from mujoco_playground._src import mjx_env
-
 RODENT_PATH = epath.Path(__file__).parent
 
 RODENT_XML_PATH = RODENT_PATH / "xmls" / "rodent.xml"

--- a/vnl_playground/tasks/rodent/imitation.py
+++ b/vnl_playground/tasks/rodent/imitation.py
@@ -1,23 +1,24 @@
 import collections
-import tqdm
 import warnings
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
 
 import brax.math
 import jax
 import jax.numpy as jp
 import mujoco
 import numpy as np
+import tqdm
 from ml_collections import config_dict
 from mujoco import mjx
 from mujoco_playground._src import mjx_env
-from jax import flatten_util
+
+from vnl_playground.tasks.reference_clips import ReferenceClips
+from vnl_playground.tasks.reward_registry import RewardRegistry
 
 from .. import utils
 from . import base as rodent_base
 from . import consts
-from vnl_playground.tasks.reference_clips import ReferenceClips
-from vnl_playground.tasks.reward_registry import RewardRegistry
 
 _registry = RewardRegistry()
 
@@ -90,8 +91,8 @@ class Imitation(rodent_base.RodentEnv):
     def __init__(
         self,
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any], dict]]] = None,
-        clips: Optional[ReferenceClips] = None,
+        config_overrides: dict[str, str | int | list[Any] | dict] | None = None,
+        clips: ReferenceClips | None = None,
     ) -> None:
         """
         Initialize the rodent imitation environment.
@@ -145,14 +146,15 @@ class Imitation(rodent_base.RodentEnv):
             warnings.warn(
                 f"Environment `rescale_factor` ({self._config.rescale_factor})"
                 f" does not match the reference data `SCALE_FACTOR`"
-                f" ({self.reference_clips._config['model']['SCALE_FACTOR']})."
+                f" ({self.reference_clips._config['model']['SCALE_FACTOR']}).",
+                stacklevel=2,
             )
 
     def reset(
         self,
         rng: jax.Array,
-        clip_idx: Optional[int] = None,
-        start_frame: Optional[int] = None,
+        clip_idx: int | None = None,
+        start_frame: int | None = None,
     ) -> mjx_env.State:
         """
         Resets the environment state: draws a new reference clip and initializes the rodent's pose to match.
@@ -492,12 +494,12 @@ class Imitation(rodent_base.RodentEnv):
 
     def render(
         self,
-        trajectory: List[mjx_env.State],
+        trajectory: list[mjx_env.State],
         height: int = 240,
         width: int = 320,
-        camera: Optional[str] = None,
-        scene_option: Optional[mujoco.MjvOption] = None,
-        modify_scene_fns: Optional[Sequence[Callable[[mujoco.MjvScene], None]]] = None,
+        camera: str | None = None,
+        scene_option: mujoco.MjvOption | None = None,
+        modify_scene_fns: Sequence[Callable[[mujoco.MjvScene], None]] | None = None,
         add_labels=False,
         termination_extra_frames=0,
         render_ghost: bool = True,
@@ -528,10 +530,7 @@ class Imitation(rodent_base.RodentEnv):
         Returns:
             Sequence[np.ndarray]: List of rendered frames as numpy arrays.
         """
-        if render_ghost:
-            mj_model = self._compile_with_ghost()
-        else:
-            mj_model = self.mj_model
+        mj_model = self._compile_with_ghost() if render_ghost else self.mj_model
         mj_data = mujoco.MjData(mj_model)
 
         renderer = mujoco.Renderer(mj_model, height=height, width=width)
@@ -579,7 +578,7 @@ class Imitation(rodent_base.RodentEnv):
                     reason = "<Unknown>"
                     if state.info["truncated"]:
                         reason = "truncated"
-                    for name in self._config.termination_criteria.keys():
+                    for name in self._config.termination_criteria:
                         if state.metrics["terminations/" + name] > 0:
                             reason = name
                     cv2.putText(
@@ -606,10 +605,10 @@ class Imitation(rodent_base.RodentEnv):
         rollout_source: Any,
         height: int = 480,
         width: int = 640,
-        camera: Optional[str] = None,
-        scene_option: Optional[mujoco.MjvOption] = None,
+        camera: str | None = None,
+        scene_option: mujoco.MjvOption | None = None,
         render_ghost: bool = True,
-    ) -> List[np.ndarray]:
+    ) -> list[np.ndarray]:
         """Render from precomputed qposes using the old track-mjx logic.
 
         Accepts either a rollout dictionary containing ``qposes_rollout`` and
@@ -700,8 +699,8 @@ class Imitation(rodent_base.RodentEnv):
             checks["joints"] = jp.allclose(
                 self._get_joint_angles(data), reference.joints, atol=atol
             )
-            body_pos = self._get_bodies_pos(data, flatten=False)
-            for body_name, body_pos in body_pos.items():
+            body_positions = self._get_bodies_pos(data, flatten=False)
+            for body_name, body_pos in body_positions.items():
                 checks[f"body_xpos/{body_name}"] = jp.allclose(
                     body_pos, reference.body_xpos(body_name), atol=atol
                 )
@@ -745,7 +744,8 @@ class Imitation(rodent_base.RodentEnv):
                     warnings.warn(
                         f"Reference data verification failed for {n_failed} frames"
                         f" for check '{name}' for clip {clip} ({clip_label})."
-                        f" First failure at frame {first_failed_frame}."
+                        f" First failure at frame {first_failed_frame}.",
+                        stacklevel=2,
                     )
                     any_failed = True
         return not any_failed

--- a/vnl_playground/tasks/rodent/joystick.py
+++ b/vnl_playground/tasks/rodent/joystick.py
@@ -11,20 +11,18 @@ rodent-scale velocities and reward structure.
 """
 
 import collections
-from typing import Any, Callable, Dict, Mapping, Optional, Union
+from typing import Any
 
 import jax
 import jax.numpy as jp
 import numpy as np
-from jax import flatten_util
 from ml_collections import config_dict
 from mujoco import mjx
-
 from mujoco_playground._src import mjx_env
 
+from vnl_playground.tasks.reward_registry import RewardRegistry
 from vnl_playground.tasks.rodent import base as rodent_base
 from vnl_playground.tasks.rodent import consts
-from vnl_playground.tasks.reward_registry import RewardRegistry
 
 _registry = RewardRegistry()
 
@@ -102,7 +100,7 @@ class Joystick(rodent_base.RodentEnv):
         self,
         rng: jax.Array = jax.random.PRNGKey(0),
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any]]]] = None,
+        config_overrides: dict[str, str | int | list[Any]] | None = None,
     ) -> None:
         """Initialize the Joystick environment.
 

--- a/vnl_playground/tasks/rodent/maintain_velocity.py
+++ b/vnl_playground/tasks/rodent/maintain_velocity.py
@@ -10,21 +10,19 @@ Termination occurs if:
 """
 
 import collections
-from typing import Any, Callable, Dict, Mapping, Optional, Union
+from typing import Any
 
 import jax
 import jax.numpy as jp
 import numpy as np
-from jax import flatten_util
 from ml_collections import config_dict
 from mujoco import mjx
-
 from mujoco_playground._src import mjx_env
 from mujoco_playground._src import reward as reward_fns
 
+from vnl_playground.tasks.reward_registry import RewardRegistry
 from vnl_playground.tasks.rodent import base as rodent_base
 from vnl_playground.tasks.rodent import consts
-from vnl_playground.tasks.reward_registry import RewardRegistry
 
 _registry = RewardRegistry()
 
@@ -78,7 +76,7 @@ class MaintainVelocity(rodent_base.RodentEnv):
         self,
         rng: jax.Array = jax.random.PRNGKey(0),
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any]]]] = None,
+        config_overrides: dict[str, str | int | list[Any]] | None = None,
     ) -> None:
         """Initialize the MaintainVelocity environment.
 

--- a/vnl_playground/tasks/rodent/rearing.py
+++ b/vnl_playground/tasks/rodent/rearing.py
@@ -5,21 +5,19 @@ above a target height relative to its torso, emulating a rearing motion.
 """
 
 import collections
-from typing import Any, Callable, Dict, Mapping, Optional, Union
+from typing import Any
 
 import jax
 import jax.numpy as jp
 import numpy as np
-from jax import flatten_util
 from ml_collections import config_dict
 from mujoco import mjx
-
 from mujoco_playground._src import mjx_env
 from mujoco_playground._src import reward as reward_fns
 
+from vnl_playground.tasks.reward_registry import RewardRegistry
 from vnl_playground.tasks.rodent import base as rodent_base
 from vnl_playground.tasks.rodent import consts
-from vnl_playground.tasks.reward_registry import RewardRegistry
 
 _registry = RewardRegistry()
 
@@ -68,7 +66,7 @@ class Rearing(rodent_base.RodentEnv):
     def __init__(
         self,
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any]]]] = None,
+        config_overrides: dict[str, str | int | list[Any]] | None = None,
     ) -> None:
         super().__init__(config, config_overrides)
 

--- a/vnl_playground/tasks/rodent/sparse_imitation.py
+++ b/vnl_playground/tasks/rodent/sparse_imitation.py
@@ -11,7 +11,8 @@ Key behavior:
 """
 
 import collections
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
 
 import jax
 import jax.numpy as jp
@@ -20,13 +21,13 @@ import numpy as np
 from ml_collections import config_dict
 from mujoco import mjx
 from mujoco_playground._src import mjx_env
-from jax import flatten_util
+
+from vnl_playground.tasks.reference_clips import ReferenceClips
+from vnl_playground.tasks.reward_registry import RewardRegistry
 
 from .. import utils
 from . import base as rodent_base
 from . import consts
-from vnl_playground.tasks.reference_clips import ReferenceClips
-from vnl_playground.tasks.reward_registry import RewardRegistry
 
 _registry = RewardRegistry()
 
@@ -101,8 +102,8 @@ class SparseImitation(rodent_base.RodentEnv):
     def __init__(
         self,
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any], dict]]] = None,
-        clips: Optional[ReferenceClips] = None,
+        config_overrides: dict[str, str | int | list[Any] | dict] | None = None,
+        clips: ReferenceClips | None = None,
     ) -> None:
         """Initialize the sparse imitation environment.
 
@@ -171,7 +172,7 @@ class SparseImitation(rodent_base.RodentEnv):
     def reset(
         self,
         rng: jax.Array,
-        clip_idx: Optional[int] = None,
+        clip_idx: int | None = None,
     ) -> mjx_env.State:
         """Reset the environment state.
 
@@ -571,7 +572,7 @@ class SparseImitation(rodent_base.RodentEnv):
             new_max: Updated max_steps array
             complete: Boolean, True if full sequence matched
         """
-        L = ref_joints.shape[0]
+        ref_joints.shape[0]
         INF = jp.iinfo(jp.int32).max // 4
         NINF = -INF
         tolerance = self._config.tolerance
@@ -722,12 +723,12 @@ class SparseImitation(rodent_base.RodentEnv):
 
     def render(
         self,
-        trajectory: List[mjx_env.State],
+        trajectory: list[mjx_env.State],
         height: int = 240,
         width: int = 320,
-        camera: Optional[str] = None,
-        scene_option: Optional[mujoco.MjvOption] = None,
-        modify_scene_fns: Optional[Sequence[Callable[[mujoco.MjvScene], None]]] = None,
+        camera: str | None = None,
+        scene_option: mujoco.MjvOption | None = None,
+        modify_scene_fns: Sequence[Callable[[mujoco.MjvScene], None]] | None = None,
         render_ghost: bool = True,
     ) -> Sequence[np.ndarray]:
         """Render a sequence of states (trajectory).

--- a/vnl_playground/tasks/rodent/visualize.py
+++ b/vnl_playground/tasks/rodent/visualize.py
@@ -1,14 +1,11 @@
-from vnl_playground.tasks.rodent import base as rodent_base
-from vnl_playground.tasks.rodent import consts
-
-from mujoco_playground._src import mjx_env
-
 import jax
 import jax.numpy as jp
+from mujoco_playground._src import mjx_env
+
+from vnl_playground.tasks.rodent import base as rodent_base
 
 
 class RodentRender(rodent_base.RodentEnv):
-
     def reset(self, rng: jax.Array) -> mjx_env.State:
         data = mjx_env.init(self.mjx_model)
         reward, done, obs = jp.zeros(3)

--- a/vnl_playground/tasks/stick/base.py
+++ b/vnl_playground/tasks/stick/base.py
@@ -1,24 +1,23 @@
 """Base classes for stick bug (Sungaya inexpectata)."""
 
 import collections
-from typing import Any, Dict, Mapping, Optional, Union
+import logging
+from collections.abc import Mapping
+from typing import Any
 
-from etils import epath
 import jax
 import jax.numpy as jp
-import logging
-import numpy as np
-from ml_collections import config_dict
 import mujoco
+from ml_collections import config_dict
 from mujoco import mjx
-
 from mujoco_playground._src import mjx_env
-from vnl_playground.tasks.stick import consts
+
 from vnl_playground.tasks.reward_registry import RewardRegistry
-from vnl_playground.tasks.utils import _scale_body_tree, _recolour_tree, scale_spec
+from vnl_playground.tasks.stick import consts
+from vnl_playground.tasks.utils import _recolour_tree, scale_spec
 
 
-def get_assets() -> Dict[str, bytes]:
+def get_assets() -> dict[str, bytes]:
     assets = {}
     mjx_env.update_assets(assets, consts.STICK_PATH / "xmls", "*.xml")
     return assets
@@ -49,7 +48,7 @@ class StickBugEnv(mjx_env.MjxEnv):
     def __init__(
         self,
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any]]]] = None,
+        config_overrides: dict[str, str | int | list[Any]] | None = None,
     ) -> None:
         super().__init__(config, config_overrides)
         self._walker_xml_path = str(config.walker_xml_path)
@@ -63,7 +62,7 @@ class StickBugEnv(mjx_env.MjxEnv):
         rescale_factor: float = 1.0,
         pos: tuple[float, float, float] = (0, 0, 0),
         quat: tuple[float, float, float, float] = (1, 0, 0, 0),
-        rgba: Optional[tuple[float, float, float, float]] = None,
+        rgba: tuple[float, float, float, float] | None = None,
         suffix: str = "-stick",
     ) -> None:
         """Adds the stick bug model to the environment.
@@ -100,9 +99,7 @@ class StickBugEnv(mjx_env.MjxEnv):
         # Attach the reference_base body (root of the stick bug).
         # The stick XML already contains a free joint named "root",
         # so we do NOT call add_freejoint() here.
-        spawn_body = spawn_frame.attach_body(
-            stick.body("reference_base"), "", suffix=suffix
-        )
+        spawn_frame.attach_body(stick.body("reference_base"), "", suffix=suffix)
         self._suffix = suffix
 
         # Add explicit floor-foot contact pairs.
@@ -158,7 +155,7 @@ class StickBugEnv(mjx_env.MjxEnv):
 
     def _get_appendages_pos(
         self, data: mjx.Data, flatten: bool = True
-    ) -> Union[dict[str, jp.ndarray], jp.ndarray]:
+    ) -> dict[str, jp.ndarray] | jp.ndarray:
         """Get egocentric position of the end effectors (claws)."""
         root = data.bind(
             self.mjx_model,
@@ -178,7 +175,7 @@ class StickBugEnv(mjx_env.MjxEnv):
 
     def _get_bodies_pos(
         self, data: mjx.Data, flatten: bool = True
-    ) -> Union[dict[str, jp.ndarray], jp.ndarray]:
+    ) -> dict[str, jp.ndarray] | jp.ndarray:
         """Get global positions of the body parts."""
         bodies_pos = collections.OrderedDict()
         for body_name in consts.BODIES:
@@ -216,7 +213,7 @@ class StickBugEnv(mjx_env.MjxEnv):
 
     def _get_proprioception(
         self, data: mjx.Data, info: Mapping[str, Any], flatten: bool = True
-    ) -> Union[jp.ndarray, Mapping[str, jp.ndarray]]:
+    ) -> jp.ndarray | Mapping[str, jp.ndarray]:
         """Get proprioception data from the environment."""
         proprioception = collections.OrderedDict(
             joint_angles=self._get_joint_angles(data),
@@ -234,7 +231,7 @@ class StickBugEnv(mjx_env.MjxEnv):
 
     def _get_kinematic_sensors(
         self, data: mjx.Data, flatten: bool = True
-    ) -> Union[Mapping[str, jp.ndarray], jp.ndarray]:
+    ) -> Mapping[str, jp.ndarray] | jp.ndarray:
         """Get kinematic sensors data from the environment."""
         accelerometer = data.bind(
             self.mjx_model,

--- a/vnl_playground/tasks/stick/imitation.py
+++ b/vnl_playground/tasks/stick/imitation.py
@@ -7,7 +7,8 @@ loaded via the unified ReferenceClips class.
 
 import collections
 import warnings
-from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Union
+from collections.abc import Callable, Mapping, Sequence
+from typing import Any
 
 import brax.math
 import jax
@@ -17,13 +18,13 @@ import numpy as np
 from ml_collections import config_dict
 from mujoco import mjx
 from mujoco_playground._src import mjx_env
-from jax import flatten_util
+
+from vnl_playground.tasks.reference_clips import ReferenceClips
+from vnl_playground.tasks.reward_registry import RewardRegistry
 
 from .. import utils
 from . import base as stick_base
 from . import consts
-from vnl_playground.tasks.reference_clips import ReferenceClips
-from vnl_playground.tasks.reward_registry import RewardRegistry
 
 
 def default_config() -> config_dict.ConfigDict:
@@ -83,8 +84,8 @@ class Imitation(stick_base.StickBugEnv):
     def __init__(
         self,
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any], dict]]] = None,
-        clips: Optional[ReferenceClips] = None,
+        config_overrides: dict[str, str | int | list[Any] | dict] | None = None,
+        clips: ReferenceClips | None = None,
     ) -> None:
         super().__init__(config, config_overrides)
         self.add_stick(
@@ -123,14 +124,15 @@ class Imitation(stick_base.StickBugEnv):
             warnings.warn(
                 f"Environment `rescale_factor` ({self._config.rescale_factor})"
                 f" does not match the reference data `SCALE_FACTOR`"
-                f" ({self.reference_clips._config['model']['SCALE_FACTOR']})."
+                f" ({self.reference_clips._config['model']['SCALE_FACTOR']}).",
+                stacklevel=2,
             )
 
     def reset(
         self,
         rng: jax.Array,
-        clip_idx: Optional[int] = None,
-        start_frame: Optional[int] = None,
+        clip_idx: int | None = None,
+        start_frame: int | None = None,
     ) -> mjx_env.State:
         start_rng, clip_rng = jax.random.split(rng)
         if clip_idx is None:
@@ -420,12 +422,12 @@ class Imitation(stick_base.StickBugEnv):
 
     def render(
         self,
-        trajectory: List[mjx_env.State],
+        trajectory: list[mjx_env.State],
         height: int = 240,
         width: int = 320,
-        camera: Optional[str] = None,
-        scene_option: Optional[mujoco.MjvOption] = None,
-        modify_scene_fns: Optional[Sequence[Callable[[mujoco.MjvScene], None]]] = None,
+        camera: str | None = None,
+        scene_option: mujoco.MjvOption | None = None,
+        modify_scene_fns: Sequence[Callable[[mujoco.MjvScene], None]] | None = None,
         add_labels=False,
         termination_extra_frames=0,
         render_ghost: bool = True,

--- a/vnl_playground/tasks/stick/maintain_velocity.py
+++ b/vnl_playground/tasks/stick/maintain_velocity.py
@@ -11,21 +11,19 @@ Termination occurs if:
 """
 
 import collections
-from typing import Any, Dict, Mapping, Optional, Union
+from typing import Any
 
 import jax
 import jax.numpy as jp
 import numpy as np
-from jax import flatten_util
 from ml_collections import config_dict
 from mujoco import mjx
-
 from mujoco_playground._src import mjx_env
 from mujoco_playground._src import reward as reward_fns
 
+from vnl_playground.tasks.reward_registry import RewardRegistry
 from vnl_playground.tasks.stick import base as stick_base
 from vnl_playground.tasks.stick import consts
-from vnl_playground.tasks.reward_registry import RewardRegistry
 
 
 def default_config() -> config_dict.ConfigDict:
@@ -74,7 +72,7 @@ class MaintainVelocity(stick_base.StickBugEnv):
         self,
         rng: jax.Array = jax.random.PRNGKey(0),
         config: config_dict.ConfigDict = default_config(),
-        config_overrides: Optional[Dict[str, Union[str, int, list[Any]]]] = None,
+        config_overrides: dict[str, str | int | list[Any]] | None = None,
     ) -> None:
         super().__init__(config, config_overrides)
         self._rng = rng

--- a/vnl_playground/tasks/utils.py
+++ b/vnl_playground/tasks/utils.py
@@ -1,7 +1,6 @@
 """Utility functions for scaling and recoloring geometries in a MuJoCo model, and rendering rollouts."""
 
 import numpy as np
-from typing import Any, Tuple
 
 
 def _scale_vec(vec: list[float] | np.ndarray, s: float) -> None:

--- a/vnl_playground/tasks/wrappers.py
+++ b/vnl_playground/tasks/wrappers.py
@@ -4,15 +4,14 @@ These wrappers are generic and work with any MjxEnv-based environment,
 including rodent, fruitfly, and future organisms.
 """
 
-from typing import Any, Callable, Mapping
-
-from mujoco import mjx
-from mujoco_playground._src import mjx_env
+from collections.abc import Callable, Mapping
+from typing import Any
 
 import jax
 import jax.numpy as jp
-
+from mujoco import mjx
 from mujoco_playground import wrapper
+from mujoco_playground._src import mjx_env
 
 
 class FlattenObsWrapper(wrapper.Wrapper):

--- a/vnl_playground/train_imitation.py
+++ b/vnl_playground/train_imitation.py
@@ -15,28 +15,21 @@ os.environ["PYOPENGL_PLATFORM"] = "egl"
 import functools
 import json
 from datetime import datetime
-import numpy as np
-import imageio
 
+import imageio
 import jax
 import jax.numpy as jp
-import matplotlib.pyplot as plt
-import mediapy as media
 import mujoco
+import numpy as np
 import wandb
+from brax.training.acme import running_statistics
 from brax.training.agents.ppo import networks as ppo_networks
 from brax.training.agents.ppo import train as ppo
-from brax.training.acme import running_statistics
-
 from etils import epath
 from flax.training import orbax_utils
-from IPython.display import clear_output, display
-from orbax import checkpoint as ocp
 from ml_collections import config_dict
-from tqdm import tqdm
-
-from mujoco_playground import locomotion, wrapper
-from mujoco_playground.config import locomotion_params
+from mujoco_playground import wrapper
+from orbax import checkpoint as ocp
 
 from vnl_playground.tasks.rodent import imitation
 from vnl_playground.tasks.rodent import wrappers as rodent_wrappers
@@ -52,7 +45,7 @@ env_cfg.keep_clips_idx = np.arange(50)
 
 ppo_params = config_dict.create(
     num_envs=4096,
-    num_timesteps=int(4_000_000_000),
+    num_timesteps=4_000_000_000,
     batch_size=1024,
     num_minibatches=16,
     num_updates_per_batch=3,
@@ -146,7 +139,12 @@ del training_params["eval_every"]
 network_factory = functools.partial(
     ppo_networks.make_ppo_networks, **ppo_params.network_factory
 )
-normalize = lambda x, y: x
+
+
+def normalize(x, y):
+    return x
+
+
 if training_params["normalize_observations"]:
     normalize = running_statistics.normalize
 
@@ -242,7 +240,7 @@ if __name__ == "__main__":
         qposes_rollout = np.array([state.data.qpos for state in rollout])
         video_path = f"{ckpt_path}/{current_step}.mp4"
 
-        with imageio.get_writer(video_path, fps=int((1.0 / env.dt))) as video:
+        with imageio.get_writer(video_path, fps=int(1.0 / env.dt)) as video:
             for qpos in qposes_rollout:
                 mj_data.qpos = qpos
                 mujoco.mj_forward(mj_model, mj_data)

--- a/vnl_playground/train_intention.py
+++ b/vnl_playground/train_intention.py
@@ -3,7 +3,6 @@ Entry point for track-mjx. Load the config file, create environments, initialize
 """
 
 import os
-import sys
 
 # set default env variable if not set
 # os.environ["XLA_PYTHON_CLIENT_MEM_FRACTION"] = os.environ.get(
@@ -30,23 +29,20 @@ jax.config.update(
     "jax_persistent_cache_enable_xla_caches", "xla_gpu_per_fusion_autotune_cache_dir"
 )
 
-import hydra
-from omegaconf import DictConfig, OmegaConf
 import functools
-import wandb
-import orbax.checkpoint as ocp
-from track_mjx.agent.mlp_ppo import ppo, ppo_networks
-import warnings
-from pathlib import Path
-from datetime import datetime
 import logging
+import warnings
+from datetime import datetime
+
+import hydra
 import mujoco
+import orbax.checkpoint as ocp
+import wandb
+from omegaconf import DictConfig, OmegaConf
+from track_mjx.agent import checkpointing, wandb_logging
+from track_mjx.agent.mlp_ppo import ppo, ppo_networks
 
-from vnl_playground.tasks.rodent import flat_arena, bowl_escape, maze_forage
-
-from track_mjx.agent import checkpointing
-from track_mjx.agent import wandb_logging
-from track_mjx.analysis import render
+from vnl_playground.tasks.rodent import bowl_escape, flat_arena, maze_forage
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
@@ -57,7 +53,7 @@ def main(cfg: DictConfig):
     try:
         n_devices = jax.device_count(backend="gpu")
         logging.info(f"Using {n_devices} GPUs")
-    except:
+    except Exception:
         n_devices = 1
         logging.info("Not using GPUs")
 
@@ -80,26 +76,17 @@ def main(cfg: DictConfig):
             checkpointing.load_config_from_checkpoint(checkpoint_to_restore)
         )
         print(
-            "Overwriting decoder layer sizes from checkpoint from {} to {}".format(
-                cfg.network_config.decoder_layer_sizes,
-                cfg_loaded.network_config.decoder_layer_sizes,
-            )
+            f"Overwriting decoder layer sizes from checkpoint from {cfg.network_config.decoder_layer_sizes} to {cfg_loaded.network_config.decoder_layer_sizes}"
         )
         cfg.network_config.decoder_layer_sizes = (
             cfg_loaded.network_config.decoder_layer_sizes
         )
         print(
-            "Overwriting intention size from checkpoint from {} to {}".format(
-                cfg.network_config.intention_size,
-                cfg_loaded.network_config.intention_size,
-            )
+            f"Overwriting intention size from checkpoint from {cfg.network_config.intention_size} to {cfg_loaded.network_config.intention_size}"
         )
         cfg.network_config.intention_size = cfg_loaded.network_config.intention_size
         print(
-            "Overwriting rescale factor from checkpoint from {} to {}".format(
-                cfg.walker_config.rescale_factor,
-                cfg_loaded.walker_config.rescale_factor,
-            )
+            f"Overwriting rescale factor from checkpoint from {cfg.walker_config.rescale_factor} to {cfg_loaded.walker_config.rescale_factor}"
         )
         cfg.walker_config.rescale_factor = cfg_loaded.walker_config.rescale_factor
         cfg.env_config.env_args.rescale_factor = cfg_loaded.walker_config.rescale_factor


### PR DESCRIPTION
## Summary

- replace Black with Ruff for formatting
- adopt the same E/W/F/I/UP/B/SIM/TCH/RUF lint policy used by `track-mjx`
- target the repository's supported Python 3.11 syntax
- apply the mechanical formatting and lint cleanup required to make the full `vnl_playground/` package pass
- update CI to run both `ruff format --check` and `ruff check` across the package

No runtime behavior changes are intended. Most of the diff is import ordering, modern Python annotations, explicit warning stack levels, removal of unused bindings, and small lint-driven simplifications.
