### PR TITLE
fix: configure MJX capacity per world

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,14 +20,14 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",]
 dependencies = [
-    "brax==0.14.0",
+    "brax @ git+https://github.com/google/brax.git@303d89dfac42919e5fde7c91f24c28a505373b24",
     "wandb",
-    "mujoco",
+    "mujoco==3.11.0",
     "dm_control",
-    "mujoco-mjx[warp]>=3.4.0",
-    "warp-lang>=1.11.0",
+    "mujoco-mjx[warp]==3.11.0",
+    "warp-lang==1.14.0",
     "mediapy",
-    "jax>=0.7.2",
+    "jax==0.10.2",
     "flax",
     "imageio[ffmpeg]",
     "hydra-core",
@@ -52,8 +52,8 @@ readme = {file = ["README.md"], content-type="text/markdown"}
 version_file = "vnl_playground/_version.py"
 
 [project.optional-dependencies]
-cuda12 = ["jax[cuda12]>=0.7.2 ; sys_platform == 'linux'"]
-cuda13 = ["jax[cuda13]>=0.7.2 ; sys_platform == 'linux'"]
+cuda12 = ["jax[cuda12]==0.10.2 ; sys_platform == 'linux'"]
+cuda13 = ["jax[cuda13]==0.10.2 ; sys_platform == 'linux'"]
 dev = [
     "pytest",
     "ruff>=0.11",
@@ -62,7 +62,7 @@ dev = [
 with-cuda = [
     "vnl-playground[dev]",
     "flax[all]",
-    "jax[cuda12]>=0.7.2",
+    "jax[cuda12]==0.10.2",
 ]
 
 [project.urls]

--- a/vnl_playground/tasks/__init__.py
+++ b/vnl_playground/tasks/__init__.py
@@ -63,6 +63,7 @@ _cfgs = {
     "StickMaintainVelocity": stick_maintain_velocity.default_config,
     "StickImitation": stick_imitation.default_config,
     "WormImitation": worm_imitation.default_config,
+    "CelegansImitation": worm_imitation.default_config,
 }
 
 # Environments that consume reference clips.
@@ -73,6 +74,7 @@ _reference_clip_envs = {
     "MouseImitation",
     "StickImitation",
     "WormImitation",
+    "CelegansImitation",
 }
 
 

--- a/vnl_playground/tasks/celegans/base.py
+++ b/vnl_playground/tasks/celegans/base.py
@@ -82,8 +82,8 @@ def default_config() -> config_dict.ConfigDict:
         noslip_iterations=0,
         ccd_iterations=35,
         impratio=0.1,
-        naconmax=16 * 256,
-        njmax=256,
+        contacts_per_world=64,
+        constraints_per_world=256,
         mujoco_impl="jax",
     )
 
@@ -102,6 +102,7 @@ class CelegansEnv(mjx_env.MjxEnv):
         self,
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any]] | None = None,
+        num_worlds: int = 1,
     ) -> None:
         """Initialize the CelegansEnv class with only arena.
 
@@ -110,6 +111,7 @@ class CelegansEnv(mjx_env.MjxEnv):
             config_overrides: Optional overrides for the configuration.
         """
         super().__init__(config, config_overrides)
+        self._num_worlds = num_worlds
         self._walker_xml_path = str(self.get_param("walker_xml_path"))
         self._arena_xml_path = str(self.get_param("arena_xml_path"))
         self._spec = mujoco.MjSpec.from_file(self._arena_xml_path)
@@ -146,8 +148,8 @@ class CelegansEnv(mjx_env.MjxEnv):
                     "solver": self.get_param("solver"),
                     "ls_iterations": self.get_param("ls_iterations"),
                     "noslip_iterations": self.get_param("noslip_iterations"),
-                    "naconmax": self.get_param("naconmax"),
-                    "njmax": self.get_param("njmax"),
+                    "contacts_per_world": self.get_param("contacts_per_world"),
+                    "constraints_per_world": self.get_param("constraints_per_world"),
                 },
                 "mujoco_impl": self.get_param("mujoco_impl"),
             }

--- a/vnl_playground/tasks/celegans/imitation.py
+++ b/vnl_playground/tasks/celegans/imitation.py
@@ -102,6 +102,7 @@ class Imitation(worm_base.CelegansEnv):
         config_overrides: dict[str, str | int | list[Any] | dict[str, Any]]
         | None = None,
         clips: ReferenceClips | None = None,
+        num_worlds: int = 1,
     ) -> None:
         """Initialize the imitation environment.
 
@@ -109,7 +110,7 @@ class Imitation(worm_base.CelegansEnv):
             config: Configuration dictionary for the environment.
             config_overrides: Optional overrides for the configuration.
         """
-        super().__init__(config, config_overrides)
+        super().__init__(config, config_overrides, num_worlds)
 
         # ConfigDict annoyingly sorts dictionary by keys
         friction = [
@@ -418,8 +419,8 @@ class Imitation(worm_base.CelegansEnv):
         data = mjx.make_data(
             self.mj_model,
             impl=self._config.mujoco_impl,
-            naconmax=self._config.naconmax,
-            njmax=self._config.njmax,
+            naconmax=self._config.contacts_per_world * self._num_worlds,
+            njmax=self._config.constraints_per_world,
         )
         reference = self.reference_clips.at(clip=clip_idx, frame=start_frame)
         data = data.replace(qpos=reference.qpos)

--- a/vnl_playground/tasks/fruitfly/base.py
+++ b/vnl_playground/tasks/fruitfly/base.py
@@ -40,6 +40,8 @@ def default_config() -> config_dict.ConfigDict:
         ls_iterations=5,
         noslip_iterations=0,
         mujoco_impl="jax",
+        contacts_per_world=16,
+        constraints_per_world=64,
     )
 
 
@@ -54,6 +56,7 @@ class FruitflyEnv(mjx_env.MjxEnv):
         self,
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any]] | None = None,
+        num_worlds: int = 1,
     ) -> None:
         """
         Initialize the FruitflyEnv class with only arena
@@ -64,6 +67,7 @@ class FruitflyEnv(mjx_env.MjxEnv):
             compile_spec (bool, optional): Whether to compile the model. Defaults to False.
         """
         super().__init__(config, config_overrides)
+        self._num_worlds = num_worlds
         self._walker_xml_path = str(config.walker_xml_path)
         self._arena_xml_path = str(config.arena_xml_path)
         self._spec = mujoco.MjSpec.from_file(str(config.arena_xml_path))

--- a/vnl_playground/tasks/fruitfly/imitation.py
+++ b/vnl_playground/tasks/fruitfly/imitation.py
@@ -33,7 +33,8 @@ def default_config() -> config_dict.ConfigDict:
         root_body="thorax",
         end_effectors=consts.END_EFFECTORS,
         mujoco_impl="warp",  # Use warp backend for faster testing
-        naconmax=1024 * 10,
+        contacts_per_world=16,
+        constraints_per_world=64,
         sim_dt=0.0002,  # 5000 Hz physics
         ctrl_dt=0.002,  # 500 Hz control
         solver="newton",
@@ -91,6 +92,7 @@ class Imitation(fruitfly_base.FruitflyEnv):
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any] | dict] | None = None,
         clips: ReferenceClips | None = None,
+        num_worlds: int = 1,
     ) -> None:
         """
         Initialize the fruitfly imitation environment.
@@ -100,7 +102,7 @@ class Imitation(fruitfly_base.FruitflyEnv):
             config_overrides: Dictionary of configuration overrides.
             clips: Pre-loaded ReferenceClips object.
         """
-        super().__init__(config, config_overrides)
+        super().__init__(config, config_overrides, num_worlds)
         # self.add_fly(
         #     rescale_factor=self._config.rescale_factor,
         #     torque_actuators=self._config.torque_actuators,
@@ -226,7 +228,10 @@ class Imitation(fruitfly_base.FruitflyEnv):
 
     def _reset_data(self, clip_idx: int, start_frame: int) -> mjx.Data:
         data = mjx.make_data(
-            self.mj_model, impl=self._config.mujoco_impl, naconmax=self._config.naconmax
+            self.mj_model,
+            impl=self._config.mujoco_impl,
+            naconmax=self._config.contacts_per_world * self._num_worlds,
+            njmax=self._config.constraints_per_world,
         )
         reference = self.reference_clips.at(clip=clip_idx, frame=start_frame)
 

--- a/vnl_playground/tasks/fruitfly/maintain_velocity.py
+++ b/vnl_playground/tasks/fruitfly/maintain_velocity.py
@@ -34,7 +34,8 @@ def default_config() -> config_dict.ConfigDict:
         ctrl_dt=0.002,
         solver="newton",
         mujoco_impl="jax",
-        naconmax=1024 * 10,
+        contacts_per_world=16,
+        constraints_per_world=64,
         iterations=5,
         ls_iterations=5,
         noslip_iterations=0,
@@ -72,8 +73,9 @@ class MaintainVelocity(fruitfly_base.FruitflyEnv):
         rng: jax.Array = jax.random.PRNGKey(0),
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any]] | None = None,
+        num_worlds: int = 1,
     ) -> None:
-        super().__init__(config, config_overrides)
+        super().__init__(config, config_overrides, num_worlds)
         self._rng = rng
 
         init_x, init_y, init_z = 0.0, 0.0, self._config.init_z
@@ -97,7 +99,8 @@ class MaintainVelocity(fruitfly_base.FruitflyEnv):
         data = mjx.make_data(
             self.mj_model,
             impl=self._config.mujoco_impl,
-            naconmax=self._config.naconmax,
+            naconmax=self._config.contacts_per_world * self._num_worlds,
+            njmax=self._config.constraints_per_world,
         )
 
         metrics = {}

--- a/vnl_playground/tasks/mouse/base.py
+++ b/vnl_playground/tasks/mouse/base.py
@@ -47,6 +47,8 @@ def default_config() -> config_dict.ConfigDict:
         Kd=0.5,
         episode_length=150,
         mujoco_impl="jax",
+        contacts_per_world=8,
+        constraints_per_world=32,
     )
 
 
@@ -60,6 +62,7 @@ class MouseBaseEnv(mjx_env.MjxEnv):
         self,
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any]] | None = None,
+        num_worlds: int = 1,
     ) -> None:
         """
         Initialize with arena-only MjSpec; add mouse(s) later via add_mouse().
@@ -69,6 +72,7 @@ class MouseBaseEnv(mjx_env.MjxEnv):
             config_overrides: Optional overrides for fields in `config`.
         """
         super().__init__(config, config_overrides)
+        self._num_worlds = num_worlds
         self._walker_xml_path = str(config.walker_xml_path)
         self._arena_xml_path = str(config.arena_xml_path)
 

--- a/vnl_playground/tasks/mouse/imitation.py
+++ b/vnl_playground/tasks/mouse/imitation.py
@@ -81,6 +81,7 @@ class MouseImitation(MouseBaseEnv):
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any] | dict] | None = None,
         clips: ReferenceClips | None = None,
+        num_worlds: int = 1,
     ) -> None:
         """Initialize the mouse arm imitation environment.
 
@@ -89,7 +90,7 @@ class MouseImitation(MouseBaseEnv):
             config_overrides: Optional overrides for config fields.
             clips: Pre-loaded ReferenceClips. If None, loads from config path.
         """
-        super().__init__(config, config_overrides)
+        super().__init__(config, config_overrides, num_worlds)
 
         # Add mouse arm (no freejoint - fixed base)
         self.add_mouse(freejoint=False, pos=(0.0, 0.0, 0.0))
@@ -269,6 +270,8 @@ class MouseImitation(MouseBaseEnv):
         data = mjx.make_data(
             self.mj_model,
             impl=self._config.mujoco_impl,
+            naconmax=self._config.contacts_per_world * self._num_worlds,
+            njmax=self._config.constraints_per_world,
         )
 
         reference = self.reference_clips.at(clip=clip_idx, frame=start_frame)

--- a/vnl_playground/tasks/mouse/mouse_reach.py
+++ b/vnl_playground/tasks/mouse/mouse_reach.py
@@ -60,6 +60,7 @@ class MouseReach(MouseBaseEnv):
         self,
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any]] | None = None,
+        num_worlds: int = 1,
     ) -> None:
         """Initialize the mouse reaching environment.
 
@@ -70,7 +71,7 @@ class MouseReach(MouseBaseEnv):
             config: Configuration dictionary with reaching task parameters.
             config_overrides: Optional overrides for config fields.
         """
-        super().__init__(config, config_overrides)
+        super().__init__(config, config_overrides, num_worlds)
 
         # Add mouse model (no freejoint - fixed base arm)
         # Spawn at origin to match target positions from original XML
@@ -163,7 +164,12 @@ class MouseReach(MouseBaseEnv):
             target_position = self._sample_target_from_list(key)
 
         # Initialize physics data (pass impl for warp/jax compatibility)
-        data = mjx.make_data(self.mj_model, impl=self._config.mujoco_impl)
+        data = mjx.make_data(
+            self.mj_model,
+            impl=self._config.mujoco_impl,
+            naconmax=self._config.contacts_per_world * self._num_worlds,
+            njmax=self._config.constraints_per_world,
+        )
 
         # Set mocap target position
         data = data.replace(

--- a/vnl_playground/tasks/rodent/base.py
+++ b/vnl_playground/tasks/rodent/base.py
@@ -42,6 +42,8 @@ def default_config() -> config_dict.ConfigDict:
         ls_iterations=5,
         noslip_iterations=0,
         mujoco_impl="jax",
+        contacts_per_world=32,
+        constraints_per_world=256,
     )
 
 
@@ -56,6 +58,7 @@ class RodentEnv(mjx_env.MjxEnv):
         self,
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any]] | None = None,
+        num_worlds: int = 1,
     ) -> None:
         """
         Initialize the RodentEnv class with only arena
@@ -66,6 +69,7 @@ class RodentEnv(mjx_env.MjxEnv):
             compile_spec (bool, optional): Whether to compile the model. Defaults to False.
         """
         super().__init__(config, config_overrides)
+        self._num_worlds = num_worlds
         self._walker_xml_path = str(config.walker_xml_path)
         self._arena_xml_path = str(config.arena_xml_path)
         self._spec = mujoco.MjSpec.from_file(self._arena_xml_path)

--- a/vnl_playground/tasks/rodent/bowl_escape.py
+++ b/vnl_playground/tasks/rodent/bowl_escape.py
@@ -66,8 +66,8 @@ def default_config() -> config_dict.ConfigDict:
         sim_dt=0.002,
         solver="newton",
         mujoco_impl="jax",
-        naconmax=90 * 1024,
-        njmax=1200,
+        contacts_per_world=192,
+        constraints_per_world=768,
         iterations=5,
         ls_iterations=5,
         noslip_iterations=0,
@@ -103,6 +103,7 @@ class BowlEscape(rodent_base.RodentEnv):
         rng: jax.Array = jax.random.PRNGKey(0),
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any]] | None = None,
+        num_worlds: int = 1,
     ) -> None:
         """
         Initialize the BowlEscape class and set up the environment.
@@ -116,7 +117,7 @@ class BowlEscape(rodent_base.RodentEnv):
             NotImplementedError: Raised if vision is enabled.
         """
         # super has already init a spec with the provided arena xml path
-        super().__init__(config, config_overrides)
+        super().__init__(config, config_overrides, num_worlds)
         self._rng = rng
         if self._config.vision:
             raise NotImplementedError(
@@ -177,8 +178,8 @@ class BowlEscape(rodent_base.RodentEnv):
         data = mjx.make_data(
             self.mj_model,
             impl=self._config.mujoco_impl,
-            naconmax=self._config.naconmax,
-            njmax=self._config.njmax,
+            naconmax=self._config.contacts_per_world * self._num_worlds,
+            njmax=self._config.constraints_per_world,
         )
         metrics = {}
 

--- a/vnl_playground/tasks/rodent/imitation.py
+++ b/vnl_playground/tasks/rodent/imitation.py
@@ -34,13 +34,13 @@ def default_config() -> config_dict.ConfigDict:
         end_effectors=consts.END_EFFECTORS,
         touch_sensors=consts.TOUCH_SENSORS,
         mujoco_impl="jax",
+        contacts_per_world=32,
+        constraints_per_world=256,
         sim_dt=0.002,
         ctrl_dt=0.01,
         solver="newton",
         iterations=5,
         ls_iterations=5,
-        naconmax=90 * 1024,
-        njmax=1200,
         noslip_iterations=0,
         torque_actuators=True,
         rescale_factor=0.9,
@@ -95,6 +95,7 @@ class Imitation(rodent_base.RodentEnv):
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any] | dict] | None = None,
         clips: ReferenceClips | None = None,
+        num_worlds: int = 1,
     ) -> None:
         """
         Initialize the rodent imitation environment.
@@ -106,8 +107,10 @@ class Imitation(rodent_base.RodentEnv):
             clips (optional):
                 Pre-loaded ReferenceClips object. If provided, it overrides
                 loading from `config.reference_data_path`.
+            num_worlds: Number of environments that will share the MJX-Warp
+                contact buffer after vectorization.
         """
-        super().__init__(config, config_overrides)
+        super().__init__(config, config_overrides, num_worlds)
         self.add_rodent(
             rescale_factor=self._config.rescale_factor,
             torque_actuators=self._config.torque_actuators,
@@ -243,8 +246,8 @@ class Imitation(rodent_base.RodentEnv):
         data = mjx.make_data(
             self.mj_model,
             impl=self._config.mujoco_impl,
-            njmax=self._config.njmax,
-            naconmax=self._config.naconmax,
+            naconmax=self._config.contacts_per_world * self._num_worlds,
+            njmax=self._config.constraints_per_world,
         )
         reference = self.reference_clips.at(clip=clip_idx, frame=start_frame)
         _assert_all_are_prefix(

--- a/vnl_playground/tasks/rodent/joystick.py
+++ b/vnl_playground/tasks/rodent/joystick.py
@@ -42,8 +42,8 @@ def default_config() -> config_dict.ConfigDict:
         sim_dt=0.002,
         solver="newton",
         mujoco_impl="jax",
-        naconmax=90 * 1024,
-        njmax=1200,
+        contacts_per_world=80,
+        constraints_per_world=320,
         iterations=5,
         ls_iterations=5,
         noslip_iterations=0,
@@ -102,6 +102,7 @@ class Joystick(rodent_base.RodentEnv):
         rng: jax.Array = jax.random.PRNGKey(0),
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any]] | None = None,
+        num_worlds: int = 1,
     ) -> None:
         """Initialize the Joystick environment.
 
@@ -110,7 +111,7 @@ class Joystick(rodent_base.RodentEnv):
             config: Configuration dictionary.
             config_overrides: Optional configuration overrides.
         """
-        super().__init__(config, config_overrides)
+        super().__init__(config, config_overrides, num_worlds)
         self._rng = rng
 
         # Initialize rodent at origin facing forward (+x direction)
@@ -149,8 +150,8 @@ class Joystick(rodent_base.RodentEnv):
         data = mjx.make_data(
             self.mj_model,
             impl=self._config.mujoco_impl,
-            naconmax=self._config.naconmax,
-            njmax=self._config.njmax,
+            naconmax=self._config.contacts_per_world * self._num_worlds,
+            njmax=self._config.constraints_per_world,
         )
 
         metrics = {}

--- a/vnl_playground/tasks/rodent/maintain_velocity.py
+++ b/vnl_playground/tasks/rodent/maintain_velocity.py
@@ -40,8 +40,8 @@ def default_config() -> config_dict.ConfigDict:
         sim_dt=0.002,
         solver="newton",
         mujoco_impl="jax",
-        naconmax=90 * 1024,
-        njmax=1200,
+        contacts_per_world=80,
+        constraints_per_world=320,
         iterations=5,
         ls_iterations=5,
         noslip_iterations=0,
@@ -77,6 +77,7 @@ class MaintainVelocity(rodent_base.RodentEnv):
         rng: jax.Array = jax.random.PRNGKey(0),
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any]] | None = None,
+        num_worlds: int = 1,
     ) -> None:
         """Initialize the MaintainVelocity environment.
 
@@ -85,7 +86,7 @@ class MaintainVelocity(rodent_base.RodentEnv):
             config: Configuration dictionary.
             config_overrides: Optional configuration overrides.
         """
-        super().__init__(config, config_overrides)
+        super().__init__(config, config_overrides, num_worlds)
         self._rng = rng
 
         # Initialize rodent at origin facing forward (+x direction)
@@ -119,8 +120,8 @@ class MaintainVelocity(rodent_base.RodentEnv):
         data = mjx.make_data(
             self.mj_model,
             impl=self._config.mujoco_impl,
-            naconmax=self._config.naconmax,
-            njmax=self._config.njmax,
+            naconmax=self._config.contacts_per_world * self._num_worlds,
+            njmax=self._config.constraints_per_world,
         )
 
         metrics = {}

--- a/vnl_playground/tasks/rodent/rearing.py
+++ b/vnl_playground/tasks/rodent/rearing.py
@@ -31,8 +31,8 @@ def default_config() -> config_dict.ConfigDict:
         sim_dt=0.002,
         solver="newton",
         mujoco_impl="jax",
-        naconmax=90 * 1024,
-        njmax=1200,
+        contacts_per_world=80,
+        constraints_per_world=320,
         iterations=5,
         ls_iterations=5,
         noslip_iterations=0,
@@ -68,8 +68,9 @@ class Rearing(rodent_base.RodentEnv):
         self,
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any]] | None = None,
+        num_worlds: int = 1,
     ) -> None:
-        super().__init__(config, config_overrides)
+        super().__init__(config, config_overrides, num_worlds)
 
         # Initialize rodent at origin, standing pose
         init_x, init_y, init_z = 0.0, 0.0, 0.03
@@ -96,8 +97,8 @@ class Rearing(rodent_base.RodentEnv):
         data = mjx.make_data(
             self.mj_model,
             impl=self._config.mujoco_impl,
-            naconmax=self._config.naconmax,
-            njmax=self._config.njmax,
+            naconmax=self._config.contacts_per_world * self._num_worlds,
+            njmax=self._config.constraints_per_world,
         )
         # Compute forward kinematics to get body positions
         data = mjx.forward(self.mjx_model, data)

--- a/vnl_playground/tasks/rodent/sparse_imitation.py
+++ b/vnl_playground/tasks/rodent/sparse_imitation.py
@@ -40,13 +40,13 @@ def default_config() -> config_dict.ConfigDict:
         arena_xml_path=consts.ARENA_XML_PATH,
         # Simulation params
         mujoco_impl="jax",
+        contacts_per_world=32,
+        constraints_per_world=256,
         sim_dt=0.002,
         ctrl_dt=0.01,  # 100 Hz control
         solver="newton",
         iterations=5,
         ls_iterations=5,
-        naconmax=90 * 1024,
-        njmax=1200,
         noslip_iterations=0,
         torque_actuators=True,
         rescale_factor=0.9,
@@ -108,6 +108,7 @@ class SparseImitation(rodent_base.RodentEnv):
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any] | dict] | None = None,
         clips: ReferenceClips | None = None,
+        num_worlds: int = 1,
     ) -> None:
         """Initialize the sparse imitation environment.
 
@@ -117,7 +118,7 @@ class SparseImitation(rodent_base.RodentEnv):
             clips: Pre-loaded ReferenceClips object. If provided, it overrides
                 loading from `config.reference_data_path`.
         """
-        super().__init__(config, config_overrides)
+        super().__init__(config, config_overrides, num_worlds)
         self.add_rodent(
             rescale_factor=self._config.rescale_factor,
             torque_actuators=self._config.torque_actuators,
@@ -647,8 +648,8 @@ class SparseImitation(rodent_base.RodentEnv):
         data = mjx.make_data(
             self.mj_model,
             impl=self._config.mujoco_impl,
-            njmax=self._config.njmax,
-            naconmax=self._config.naconmax,
+            naconmax=self._config.contacts_per_world * self._num_worlds,
+            njmax=self._config.constraints_per_world,
         )
 
         # Get default qpos from model

--- a/vnl_playground/tasks/stick/base.py
+++ b/vnl_playground/tasks/stick/base.py
@@ -37,6 +37,8 @@ def default_config() -> config_dict.ConfigDict:
         ls_iterations=5,
         noslip_iterations=0,
         mujoco_impl="jax",
+        contacts_per_world=128,
+        constraints_per_world=512,
     )
 
 
@@ -50,8 +52,10 @@ class StickBugEnv(mjx_env.MjxEnv):
         self,
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any]] | None = None,
+        num_worlds: int = 1,
     ) -> None:
         super().__init__(config, config_overrides)
+        self._num_worlds = num_worlds
         self._walker_xml_path = str(config.walker_xml_path)
         self._arena_xml_path = str(config.arena_xml_path)
         self._spec = mujoco.MjSpec.from_file(str(config.arena_xml_path))

--- a/vnl_playground/tasks/stick/imitation.py
+++ b/vnl_playground/tasks/stick/imitation.py
@@ -41,8 +41,8 @@ def default_config() -> config_dict.ConfigDict:
         solver="newton",
         iterations=5,
         ls_iterations=5,
-        naconmax=256,
-        njmax=600,
+        contacts_per_world=128,
+        constraints_per_world=512,
         noslip_iterations=0,
         torque_actuators=False,
         rescale_factor=1.5,  # Match H5 SCALE_FACTOR
@@ -88,8 +88,9 @@ class Imitation(stick_base.StickBugEnv):
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any] | dict] | None = None,
         clips: ReferenceClips | None = None,
+        num_worlds: int = 1,
     ) -> None:
-        super().__init__(config, config_overrides)
+        super().__init__(config, config_overrides, num_worlds)
         self.add_stick(
             rescale_factor=self._config.rescale_factor,
             torque_actuators=self._config.torque_actuators,
@@ -201,8 +202,8 @@ class Imitation(stick_base.StickBugEnv):
         data = mjx.make_data(
             self.mj_model,
             impl=self._config.mujoco_impl,
-            njmax=self._config.njmax,
-            naconmax=self._config.naconmax,
+            naconmax=self._config.contacts_per_world * self._num_worlds,
+            njmax=self._config.constraints_per_world,
         )
         reference = self.reference_clips.at(clip=clip_idx, frame=start_frame)
         _assert_all_are_prefix(

--- a/vnl_playground/tasks/stick/maintain_velocity.py
+++ b/vnl_playground/tasks/stick/maintain_velocity.py
@@ -34,8 +34,8 @@ def default_config() -> config_dict.ConfigDict:
         sim_dt=0.002,
         solver="newton",
         mujoco_impl="jax",
-        naconmax=16 * 8192,
-        njmax=512,
+        contacts_per_world=128,
+        constraints_per_world=512,
         iterations=5,
         ls_iterations=5,
         noslip_iterations=0,
@@ -73,8 +73,9 @@ class MaintainVelocity(stick_base.StickBugEnv):
         rng: jax.Array = jax.random.PRNGKey(0),
         config: config_dict.ConfigDict = default_config(),
         config_overrides: dict[str, str | int | list[Any]] | None = None,
+        num_worlds: int = 1,
     ) -> None:
-        super().__init__(config, config_overrides)
+        super().__init__(config, config_overrides, num_worlds)
         self._rng = rng
 
         init_x, init_y, init_z = 0.0, 0.0, self._config.init_z
@@ -98,8 +99,8 @@ class MaintainVelocity(stick_base.StickBugEnv):
         data = mjx.make_data(
             self.mj_model,
             impl=self._config.mujoco_impl,
-            naconmax=self._config.naconmax,
-            njmax=self._config.njmax,
+            naconmax=self._config.contacts_per_world * self._num_worlds,
+            njmax=self._config.constraints_per_world,
         )
         metrics = {}
         obs = self._get_obs(data, info)

--- a/vnl_playground/train_imitation.py
+++ b/vnl_playground/train_imitation.py
@@ -31,8 +31,8 @@ from ml_collections import config_dict
 from mujoco_playground import wrapper
 from orbax import checkpoint as ocp
 
+from vnl_playground.tasks import wrappers as rodent_wrappers
 from vnl_playground.tasks.rodent import imitation
-from vnl_playground.tasks.rodent import wrappers as rodent_wrappers
 
 # Enable persistent compilation cache.
 jax.config.update("jax_compilation_cache_dir", "/tmp/jax_cache")
@@ -41,10 +41,10 @@ jax.config.update("jax_persistent_cache_min_compile_time_secs", 0)
 
 env_cfg = imitation.default_config()
 env_cfg.mujoco_impl = "warp"
-env_cfg.clip_indices = np.arange(50)
 
 ppo_params = config_dict.create(
     num_envs=4096,
+    num_eval_envs=128,
     num_timesteps=4_000_000_000,
     batch_size=1024,
     num_minibatches=16,
@@ -67,7 +67,6 @@ ppo_params = config_dict.create(
 )
 
 env_name = "imitation"
-env_cfg.nconmax *= ppo_params.num_envs
 
 from pprint import pprint
 
@@ -204,26 +203,33 @@ def make_logging_inference_fn(ppo_networks):
 
 
 if __name__ == "__main__":
-    env = rodent_wrappers.FlattenObsWrapper(imitation.Imitation(config=env_cfg))
-    eval_env = rodent_wrappers.FlattenObsWrapper(imitation.Imitation(config=env_cfg))
+    training_worlds_per_device = ppo_params.num_envs // jax.device_count()
+    env = rodent_wrappers.FlattenObsWrapper(
+        imitation.Imitation(config=env_cfg, num_worlds=training_worlds_per_device)
+    )
+    eval_env = rodent_wrappers.FlattenObsWrapper(
+        imitation.Imitation(config=env_cfg, num_worlds=ppo_params.num_eval_envs)
+    )
 
-    # render a rollout in the policy_params_fn to log to wandb at each step
-    jit_reset = jax.jit(env.reset)
-    jit_step = jax.jit(env.step)
-    rng = jax.random.PRNGKey(0)
-    start_state = jit_reset(rng)
-    mj_model = env._mj_model
+    # One-world environment used only for video rollouts.
+    rollout_env = rodent_wrappers.FlattenObsWrapper(
+        imitation.Imitation(config=env_cfg, num_worlds=1)
+    )
+    jit_reset = jax.jit(rollout_env.reset)
+    jit_step = jax.jit(rollout_env.step)
+    start_state = jit_reset(jax.random.PRNGKey(0))
+    mj_model = rollout_env._mj_model
     mj_data = mujoco.MjData(mj_model)
     renderer = mujoco.Renderer(mj_model, height=512, width=512)
     ppo_network = network_factory(
         start_state.obs.shape[-1],
-        env.action_size,
+        rollout_env.action_size,
         preprocess_observations_fn=normalize,
     )
     make_logging_policy = make_logging_inference_fn(ppo_network)
     jit_logging_inference_fn = jax.jit(make_logging_policy(deterministic=True))
 
-    def policy_params_fn(current_step, make_policy, params, jit_logging_inference_fn):
+    def policy_params_fn(current_step, make_policy, params):
         del make_policy  # Unused.
 
         # generate a rollout
@@ -240,7 +246,7 @@ if __name__ == "__main__":
         qposes_rollout = np.array([state.data.qpos for state in rollout])
         video_path = f"{ckpt_path}/{current_step}.mp4"
 
-        with imageio.get_writer(video_path, fps=int(1.0 / env.dt)) as video:
+        with imageio.get_writer(video_path, fps=int(1.0 / rollout_env.dt)) as video:
             for qpos in qposes_rollout:
                 mj_data.qpos = qpos
                 mujoco.mj_forward(mj_model, mj_data)
@@ -261,7 +267,5 @@ if __name__ == "__main__":
     make_inference_fn, params, _ = train_fn(
         environment=env,
         eval_env=eval_env,
-        policy_params_fn=functools.partial(
-            policy_params_fn, jit_logging_inference_fn=jit_logging_inference_fn
-        ),
+        policy_params_fn=policy_params_fn,
     )


### PR DESCRIPTION
Configures MJX contact and constraint capacity per world across all environments, fixes JAX/Warp model construction, and pins a compatible JAX, Brax, MuJoCo, MJX, and Warp dependency stack. Also cleans up imitation training and rollout environment setup for reliable fresh GPU installations.