### PR TITLE
Fix task state initialization with mjx.forward

### DIFF
--- a/vnl_playground/tasks/fruitfly/maintain_velocity.py
+++ b/vnl_playground/tasks/fruitfly/maintain_velocity.py
@@ -99,6 +99,7 @@ class MaintainVelocity(fruitfly_base.FruitflyEnv):
             impl=self._config.mujoco_impl,
             naconmax=self._config.naconmax,
         )
+        data = mjx.forward(self.mjx_model, data)
 
         metrics = {}
         obs = self._get_obs(data, info)

--- a/vnl_playground/tasks/rodent/bowl_escape.py
+++ b/vnl_playground/tasks/rodent/bowl_escape.py
@@ -180,6 +180,7 @@ class BowlEscape(rodent_base.RodentEnv):
             naconmax=self._config.naconmax,
             njmax=self._config.njmax,
         )
+        data = mjx.forward(self.mjx_model, data)
         metrics = {}
 
         obs = self._get_obs(data, info)

--- a/vnl_playground/tasks/rodent/joystick.py
+++ b/vnl_playground/tasks/rodent/joystick.py
@@ -152,6 +152,7 @@ class Joystick(rodent_base.RodentEnv):
             naconmax=self._config.naconmax,
             njmax=self._config.njmax,
         )
+        data = mjx.forward(self.mjx_model, data)
 
         metrics = {}
         obs = self._get_obs(data, info)

--- a/vnl_playground/tasks/rodent/maintain_velocity.py
+++ b/vnl_playground/tasks/rodent/maintain_velocity.py
@@ -122,6 +122,7 @@ class MaintainVelocity(rodent_base.RodentEnv):
             naconmax=self._config.naconmax,
             njmax=self._config.njmax,
         )
+        data = mjx.forward(self.mjx_model, data)
 
         metrics = {}
         obs = self._get_obs(data, info)

--- a/vnl_playground/tasks/stick/maintain_velocity.py
+++ b/vnl_playground/tasks/stick/maintain_velocity.py
@@ -101,6 +101,7 @@ class MaintainVelocity(stick_base.StickBugEnv):
             naconmax=self._config.naconmax,
             njmax=self._config.njmax,
         )
+        data = mjx.forward(self.mjx_model, data)
         metrics = {}
         obs = self._get_obs(data, info)
         reward = self._get_reward(data, info, metrics)


### PR DESCRIPTION
Calls mjx.forward during reset in affected task environments so observations, rewards, and termination checks use initialized simulation data.

Closes #83.